### PR TITLE
Feat/players/add get players query

### DIFF
--- a/apps/backend/src/gameplay/__tests__/new-game.service.spec.ts
+++ b/apps/backend/src/gameplay/__tests__/new-game.service.spec.ts
@@ -30,7 +30,7 @@ describe('NewGameService', () => {
         {
           provide: PlayersService,
           useValue: {
-            findPlayersByRef: jest.fn(),
+            findPlayers: jest.fn(),
           },
         },
         {
@@ -66,23 +66,29 @@ describe('NewGameService', () => {
   describe('validatePlayersExist', () => {
     it('should throw error when one or more players is not found', async () => {
       const findCardsSpy = jest
-        .spyOn(playersService, 'findPlayersByRef')
+        .spyOn(playersService, 'findPlayers')
         .mockResolvedValueOnce([MOCK_PLAYER_1]);
 
       const output = async () => await newGameService.validatePlayersExist(MOCK_PLAYER_REFS);
 
       expect(output).rejects.toThrow('One or more players not found');
-      expect(findCardsSpy).toHaveBeenCalledWith(MOCK_PLAYER_REFS);
+      expect(findCardsSpy).toHaveBeenCalledWith({
+        searchField: 'ref',
+        searchValues: MOCK_PLAYER_REFS,
+      });
     });
 
     it('should return true when all players exist', async () => {
       const findCardsSpy = jest
-        .spyOn(playersService, 'findPlayersByRef')
+        .spyOn(playersService, 'findPlayers')
         .mockResolvedValueOnce(MOCK_PLAYERS);
 
       const output = await newGameService.validatePlayersExist(MOCK_PLAYER_REFS);
 
-      expect(findCardsSpy).toHaveBeenCalledWith(MOCK_PLAYER_REFS);
+      expect(findCardsSpy).toHaveBeenCalledWith({
+        searchField: 'ref',
+        searchValues: MOCK_PLAYER_REFS,
+      });
       expect(output).toBe(true);
     });
   });

--- a/apps/backend/src/gameplay/services/new-game.service.ts
+++ b/apps/backend/src/gameplay/services/new-game.service.ts
@@ -42,7 +42,10 @@ export class NewGameService {
 
   async validatePlayersExist(playerRefs: string[]): Promise<boolean> {
     try {
-      const foundPlayers = await this.playersService.findPlayersByRef(playerRefs);
+      const foundPlayers = await this.playersService.findPlayers({
+        searchField: 'ref',
+        searchValues: playerRefs,
+      });
       if (foundPlayers?.length !== playerRefs.length) {
         throw new Error('One or more players not found');
       }

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -176,6 +176,11 @@ input GetPlayerDto {
   searchValue: String!
 }
 
+input GetPlayersInput {
+  searchField: String!
+  searchValues: [String!]!
+}
+
 type Mutation {
   createNewGame(newGameDto: CreateNewGameInput!): CreateNewGameResponse!
   createPlayer(newPlayerData: CreatePlayerInput!): Player!
@@ -212,6 +217,7 @@ type Query {
   getPlayer(getPlayerDto: GetPlayerDto!): Player
   getPlayerGameDetails(gameRef: ID!, playerRef: ID!): PlayerGameDetails
   getPlayerGameDetailsById(id: ID!): PlayerGameDetails
+  getPlayers(searchData: GetPlayersInput!): [Player!]!
 }
 
 type ResourceSpaces {

--- a/apps/backend/src/players/__mocks__/player.mock.ts
+++ b/apps/backend/src/players/__mocks__/player.mock.ts
@@ -1,5 +1,7 @@
 import { CreatePlayerInput } from '../dto/create-player.dto';
-import { GetPlayerDto, GetPlayerFieldOptions } from '../dto/get-player.dto';
+import { GetPlayerDto } from '../dto/get-player.dto';
+import { GetPlayersInput } from '../dto/get-players.dto';
+import { GetPlayerFieldOptions } from '../players.types';
 import { Player } from '../schemas/player.schema';
 
 export const MOCK_ID = 'mock_id';
@@ -26,6 +28,21 @@ export const MOCK_GET_PLAYER_BY_REF_INPUT: GetPlayerDto = {
 export const MOCK_GET_PLAYER_BY_INVALID_INPUT: GetPlayerDto = {
   searchField: 'invalid' as GetPlayerFieldOptions,
   searchValue: MOCK_ID,
+};
+
+export const MOCK_GET_PLAYERS_BY_PLAYER_ID_INPUT: GetPlayersInput = {
+  searchField: 'playerId',
+  searchValues: [MOCK_PLAYER_ID],
+};
+
+export const MOCK_GET_PLAYERS_BY_REF_INPUT: GetPlayersInput = {
+  searchField: 'ref',
+  searchValues: [MOCK_ID],
+};
+
+export const MOCK_GET_PLAYERS_BY_INVALID_INPUT: GetPlayersInput = {
+  searchField: 'invalid' as GetPlayerFieldOptions,
+  searchValues: [MOCK_ID],
 };
 
 export const MOCK_PLAYER_REF_1 = 'mock-player-ref-1';

--- a/apps/backend/src/players/dto/get-players.dto.ts
+++ b/apps/backend/src/players/dto/get-players.dto.ts
@@ -4,10 +4,10 @@ import { GetPlayerFieldOptions } from '../players.types';
 
 @ObjectType()
 @InputType()
-export class GetPlayerDto {
+export class GetPlayersInput {
   @Field(() => String)
   searchField!: GetPlayerFieldOptions;
 
-  @Field(() => String)
-  searchValue!: string;
+  @Field(() => [String])
+  searchValues!: string[];
 }

--- a/apps/backend/src/players/players.resolver.ts
+++ b/apps/backend/src/players/players.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
 import { CreatePlayerInput } from './dto/create-player.dto';
 import { GetPlayerDto } from './dto/get-player.dto';
+import { GetPlayersInput } from './dto/get-players.dto';
 import { PlayersService } from './players.service';
 import { Player } from './schemas/player.schema';
 
@@ -20,6 +21,19 @@ export class PlayersResolver {
         return this.playersService.findPlayerByRef(getPlayerDto.searchValue);
       default:
         throw new Error('playerId or ref required to find player');
+    }
+  }
+
+  @Query(() => [Player])
+  async getPlayers(@Args('searchData') searchData: GetPlayersInput): Promise<Player[]> {
+    switch (searchData.searchField) {
+      case 'playerId':
+      case 'ref':
+        return this.playersService.findPlayers(searchData);
+      default:
+        throw new Error(
+          'PlayersResolver -> Query -> getPlayers: searchField must be playerId or ref required to find player'
+        );
     }
   }
 

--- a/apps/backend/src/players/players.service.ts
+++ b/apps/backend/src/players/players.service.ts
@@ -3,6 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { CreatePlayerInput } from './dto/create-player.dto';
+import { GetPlayersInput } from './dto/get-players.dto';
 import { Player, PlayerDocument } from './schemas/player.schema';
 
 @Injectable()
@@ -18,11 +19,11 @@ export class PlayersService {
     return this.playerModel.findOne({ _id: ref });
   }
 
-  async findPlayersByRef(refs: string[]): Promise<Player[] | null | undefined> {
-    return this.playerModel.find({ _id: { $in: refs } });
-  }
-
   async findPlayerByPlayerId(playerId: string): Promise<Player | null | undefined> {
     return this.playerModel.findOne({ playerId });
+  }
+
+  async findPlayers(searchData: GetPlayersInput): Promise<Player[]> {
+    return this.playerModel.find({ [searchData.searchField]: { $in: searchData.searchValues } });
   }
 }

--- a/apps/backend/src/players/players.types.ts
+++ b/apps/backend/src/players/players.types.ts
@@ -1,0 +1,1 @@
+export type GetPlayerFieldOptions = 'playerId' | 'ref';

--- a/apps/native/src/App.tsx
+++ b/apps/native/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { StatusBar } from 'expo-status-bar';
 
 import { AllCards } from './components/cards/AllCards';
+import { AllPlayers } from './components/players/AllPlayers';
 import { GraphQLProvider } from './graphql/ApolloProvider';
 
 const App = () => {
@@ -32,6 +33,7 @@ const App = () => {
         <ButtonIcon as={AddIcon} />
       </Button>
       <AllCards />
+      <AllPlayers />
       <StatusBar style="auto" />
     </Box>
   );

--- a/apps/native/src/components/players/AllPlayers.tsx
+++ b/apps/native/src/components/players/AllPlayers.tsx
@@ -1,0 +1,28 @@
+import { Text, View } from '@gluestack-ui/themed';
+
+import { useGetPlayersQuery } from '@inno/gql';
+
+export const AllPlayers = () => {
+  const { data, loading } = useGetPlayersQuery({
+    variables: {
+      searchData: {
+        searchField: 'playerId',
+        searchValues: ['pimone', 'tumbaa'],
+      },
+    },
+  });
+  const players = data?.getPlayers;
+  if (loading && !players) {
+    return (
+      <View>
+        <Text>Loading</Text>
+      </View>
+    );
+  }
+  return (
+    <View>
+      <Text>Players</Text>
+      {players?.map((p) => <Text key={p.playerId}>{p.name}</Text>)}
+    </View>
+  );
+};

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -202,6 +202,11 @@ export type GetPlayerDto = {
   searchValue: Scalars['String']['input'];
 };
 
+export type GetPlayersInput = {
+  searchField: Scalars['String']['input'];
+  searchValues: Array<Scalars['String']['input']>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   createNewGame: CreateNewGameResponse;
@@ -269,6 +274,7 @@ export type Query = {
   getPlayer?: Maybe<Player>;
   getPlayerGameDetails?: Maybe<PlayerGameDetails>;
   getPlayerGameDetailsById?: Maybe<PlayerGameDetails>;
+  getPlayers: Array<Player>;
 };
 
 
@@ -295,6 +301,11 @@ export type QueryGetPlayerGameDetailsArgs = {
 
 export type QueryGetPlayerGameDetailsByIdArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryGetPlayersArgs = {
+  searchData: GetPlayersInput;
 };
 
 export type ResourceSpaces = {
@@ -361,12 +372,21 @@ export type GetAllCardsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetAllCardsQuery = { __typename?: 'Query', getAllCards: Array<{ __typename?: 'Card', _id: string, cardId: string, name: string, age: string, color: string, dogmaResource: string, resourceSpaces: { __typename?: 'ResourceSpaces', resourceSpace1?: string | null, resourceSpace2?: string | null, resourceSpace3?: string | null, resourceSpace4?: string | null }, resourceTotals: { __typename?: 'ResourceTotals', castles: number, crowns: number, leaves: number, lightbulbs: number, factories: number, timepieces: number }, dogmaEffects: Array<{ __typename?: 'DogmaEffect', description: string, effectTypes: Array<string>, isDemand: boolean, isOptional: boolean, repeat: boolean, specialAchievement?: string | null }> }> };
 
+export type PlayerFragmentFragment = { __typename?: 'Player', _id: string, playerId: string, name: string };
+
 export type GetPlayerQueryVariables = Exact<{
   input: GetPlayerDto;
 }>;
 
 
-export type GetPlayerQuery = { __typename?: 'Query', getPlayer?: { __typename?: 'Player', _id: string, name: string, playerId: string } | null };
+export type GetPlayerQuery = { __typename?: 'Query', getPlayer?: { __typename?: 'Player', _id: string, playerId: string, name: string } | null };
+
+export type GetPlayersQueryVariables = Exact<{
+  searchData: GetPlayersInput;
+}>;
+
+
+export type GetPlayersQuery = { __typename?: 'Query', getPlayers: Array<{ __typename?: 'Player', _id: string, playerId: string, name: string }> };
 
 export const BaseCardFragmentFragmentDoc = gql`
     fragment BaseCardFragment on Card {
@@ -410,6 +430,13 @@ export const ResourceTotalsFragmentDoc = gql`
     factories
     timepieces
   }
+}
+    `;
+export const PlayerFragmentFragmentDoc = gql`
+    fragment PlayerFragment on Player {
+  _id
+  playerId
+  name
 }
     `;
 export const GetAllCardsDocument = gql`
@@ -460,12 +487,10 @@ export type GetAllCardsQueryResult = Apollo.QueryResult<GetAllCardsQuery, GetAll
 export const GetPlayerDocument = gql`
     query GetPlayer($input: GetPlayerDto!) {
   getPlayer(getPlayerDto: $input) {
-    _id
-    name
-    playerId
+    ...PlayerFragment
   }
 }
-    `;
+    ${PlayerFragmentFragmentDoc}`;
 
 /**
  * __useGetPlayerQuery__
@@ -499,3 +524,43 @@ export type GetPlayerQueryHookResult = ReturnType<typeof useGetPlayerQuery>;
 export type GetPlayerLazyQueryHookResult = ReturnType<typeof useGetPlayerLazyQuery>;
 export type GetPlayerSuspenseQueryHookResult = ReturnType<typeof useGetPlayerSuspenseQuery>;
 export type GetPlayerQueryResult = Apollo.QueryResult<GetPlayerQuery, GetPlayerQueryVariables>;
+export const GetPlayersDocument = gql`
+    query GetPlayers($searchData: GetPlayersInput!) {
+  getPlayers(searchData: $searchData) {
+    ...PlayerFragment
+  }
+}
+    ${PlayerFragmentFragmentDoc}`;
+
+/**
+ * __useGetPlayersQuery__
+ *
+ * To run a query within a React component, call `useGetPlayersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPlayersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPlayersQuery({
+ *   variables: {
+ *      searchData: // value for 'searchData'
+ *   },
+ * });
+ */
+export function useGetPlayersQuery(baseOptions: Apollo.QueryHookOptions<GetPlayersQuery, GetPlayersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPlayersQuery, GetPlayersQueryVariables>(GetPlayersDocument, options);
+      }
+export function useGetPlayersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPlayersQuery, GetPlayersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPlayersQuery, GetPlayersQueryVariables>(GetPlayersDocument, options);
+        }
+export function useGetPlayersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetPlayersQuery, GetPlayersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetPlayersQuery, GetPlayersQueryVariables>(GetPlayersDocument, options);
+        }
+export type GetPlayersQueryHookResult = ReturnType<typeof useGetPlayersQuery>;
+export type GetPlayersLazyQueryHookResult = ReturnType<typeof useGetPlayersLazyQuery>;
+export type GetPlayersSuspenseQueryHookResult = ReturnType<typeof useGetPlayersSuspenseQuery>;
+export type GetPlayersQueryResult = Apollo.QueryResult<GetPlayersQuery, GetPlayersQueryVariables>;

--- a/packages/gql/src/players/fragments/player.fragment.gql
+++ b/packages/gql/src/players/fragments/player.fragment.gql
@@ -1,0 +1,5 @@
+fragment PlayerFragment on Player {
+  _id
+  playerId
+  name
+}

--- a/packages/gql/src/players/get-player.query.gql
+++ b/packages/gql/src/players/get-player.query.gql
@@ -1,7 +1,5 @@
 query GetPlayer($input: GetPlayerDto!) {
   getPlayer(getPlayerDto: $input) { 
-    _id
-    name
-    playerId
+    ...PlayerFragment
   }
 }

--- a/packages/gql/src/players/get-players.query.gql
+++ b/packages/gql/src/players/get-players.query.gql
@@ -1,0 +1,5 @@
+query GetPlayers($searchData: GetPlayersInput!) {
+  getPlayers(searchData: $searchData) { 
+    ...PlayerFragment
+  }
+}


### PR DESCRIPTION
## Summary

- Added new `getPlayers` query on `PlayersResolver`
- Added new `findPlayers` method on `PlayersService`
- Added new `GetPlayers` client-side query in `gql` package
- Re-run codegen to generate apollo-client helpers for new `GetPlayers` query
- Consume new `useGetPlayersQuery` hook in `@inno/native` app
- Added unit tests for new `getPlayers` query
- Updated existing tests and mocks to reference new `findPlayers` method, where applicable

## Demo

<img width="693" alt="2023-10-29_22-30-41" src="https://github.com/sbarli/innovation-tr/assets/12473529/c1de5e61-0d9c-4b7a-8ab3-ef475b64ce0d">

## Testing

### Added unit tests for `getPlayers` query

<img width="947" alt="2023-10-29_22-32-02" src="https://github.com/sbarli/innovation-tr/assets/12473529/18367f1a-5452-46f3-be80-027ef7b64cde">

### All affected tests passing

<img width="415" alt="2023-10-29_22-31-38" src="https://github.com/sbarli/innovation-tr/assets/12473529/6ee1cd65-0e5d-44ff-8415-30acd25e897a">


### Test Coverage

<img width="474" alt="2023-10-29_22-32-48" src="https://github.com/sbarli/innovation-tr/assets/12473529/27b4a367-b62e-4c9e-91a4-d233a7d0abab">
