### PR TITLE
Feat/be/new create players mutation

### DIFF
--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -120,6 +120,10 @@ input CreatePlayerInput {
   name: String!
 }
 
+input CreatePlayersInput {
+  names: String!
+}
+
 type Deck {
   EIGHT: [ID!]!
   FIVE: [ID!]!
@@ -184,6 +188,7 @@ type Mutation {
   createNewGame(newGameDto: CreateNewGameInput!): CreateNewGameResponse!
   createPlayer(newPlayerData: CreatePlayerInput!): Player!
   createPlayerGameDetails(createData: CreatePlayerGameDetailsInput!): PlayerGameDetails!
+  createPlayers(newPlayersData: CreatePlayersInput!): [Player!]!
   updateGame(id: String!, updates: UpdateGameInput!): Game
   updatePlayerGameDetails(id: ID!, updates: UpdatePlayerGameDetailsInput!): PlayerGameDetails
 }

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -121,7 +121,7 @@ input CreatePlayerInput {
 }
 
 input CreatePlayersInput {
-  names: String!
+  names: [String!]!
 }
 
 type Deck {

--- a/apps/backend/src/players/__mocks__/player.mock.ts
+++ b/apps/backend/src/players/__mocks__/player.mock.ts
@@ -1,4 +1,5 @@
 import { CreatePlayerInput } from '../dto/create-player.dto';
+import { CreatePlayersInput } from '../dto/create-players.dto';
 import { GetPlayerDto } from '../dto/get-player.dto';
 import { GetPlayersInput } from '../dto/get-players.dto';
 import { GetPlayerFieldOptions } from '../players.types';
@@ -6,10 +7,18 @@ import { Player } from '../schemas/player.schema';
 
 export const MOCK_ID = 'mock_id';
 export const MOCK_PLAYER_ID = 'mockplayer';
+export const MOCK_PLAYER_ID_2 = 'mockplayer2';
 export const MOCK_PLAYER_NAME = 'Mock Player';
+export const MOCK_PLAYER_NAME_2 = 'Mock Player 2';
+export const MOCK_PLAYER_REF_1 = 'mock-player-ref-1';
+export const MOCK_PLAYER_REF_2 = 'mock-player-ref-2';
 
 export const MOCK_PLAYER_INPUT: CreatePlayerInput = {
   name: MOCK_PLAYER_NAME,
+};
+
+export const MOCK_PLAYERS_INPUT: CreatePlayersInput = {
+  names: [MOCK_PLAYER_NAME, MOCK_PLAYER_NAME_2],
 };
 
 export const MOCK_PLAYER: Player = { _id: MOCK_ID, playerId: MOCK_PLAYER_ID, ...MOCK_PLAYER_INPUT };
@@ -44,9 +53,9 @@ export const MOCK_GET_PLAYERS_BY_INVALID_INPUT: GetPlayersInput = {
   searchValues: [MOCK_ID],
 };
 
-export const MOCK_PLAYER_REF_1 = 'mock-player-ref-1';
-export const MOCK_PLAYER_REF_2 = 'mock-player-ref-2';
-
 export const MOCK_PLAYER_1 = Object.assign({}, { ...MOCK_PLAYER, _id: MOCK_PLAYER_REF_1 });
-export const MOCK_PLAYER_2 = Object.assign({}, { ...MOCK_PLAYER, _id: MOCK_PLAYER_REF_2 });
+export const MOCK_PLAYER_2 = Object.assign(
+  {},
+  { ...MOCK_PLAYER, _id: MOCK_PLAYER_REF_2, playerId: MOCK_PLAYER_ID_2, name: MOCK_PLAYER_NAME_2 }
+);
 export const MOCK_PLAYERS = [MOCK_PLAYER_1, MOCK_PLAYER_2];

--- a/apps/backend/src/players/dto/create-players.dto.ts
+++ b/apps/backend/src/players/dto/create-players.dto.ts
@@ -3,6 +3,6 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 @ObjectType()
 @InputType()
 export class CreatePlayersInput {
-  @Field(() => String)
+  @Field(() => [String])
   names!: string[];
 }

--- a/apps/backend/src/players/dto/create-players.dto.ts
+++ b/apps/backend/src/players/dto/create-players.dto.ts
@@ -1,0 +1,8 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+@InputType()
+export class CreatePlayersInput {
+  @Field(() => String)
+  names!: string[];
+}

--- a/apps/backend/src/players/players.service.ts
+++ b/apps/backend/src/players/players.service.ts
@@ -7,16 +7,22 @@ import { VALID_PLAYER_ID_CHARACTERS } from '@inno/constants';
 import { GetPlayersInput } from './dto/get-players.dto';
 import { Player, PlayerDocument } from './schemas/player.schema';
 
+export interface ICreatePlayer {
+  name: string;
+  playerId: string;
+}
+
 @Injectable()
 export class PlayersService {
   constructor(@InjectModel(Player.name) private playerModel: Model<PlayerDocument>) {}
 
-  async create(name: string, playerId: string): Promise<Player> {
-    const createdPlayer = new this.playerModel({
-      name,
-      playerId,
-    });
+  async create(playerData: ICreatePlayer): Promise<Player> {
+    const createdPlayer = new this.playerModel(playerData);
     return createdPlayer.save();
+  }
+
+  async createPlayers(newPlayersData: ICreatePlayer[]): Promise<Player[]> {
+    return this.playerModel.insertMany(newPlayersData);
   }
 
   async findPlayerByRef(ref: string): Promise<Player | null | undefined> {


### PR DESCRIPTION
## Summary

- created new `createPlayers` mutation on `PlayersResolver`
- created new `createPlayers` method on `PlayersService`
- added new unit tests to cover new mutation
- update player mocks
- updated `create` method on `PlayersService` to expect object as input to enable type sharing across `create` and `createPlayers` methods

## Demo

<img width="1126" alt="2023-10-30_21-17-06" src="https://github.com/sbarli/innovation-tr/assets/12473529/55e18152-fde5-440c-a615-b320737ebf9d">

<img width="1710" alt="2023-10-30_21-36-19" src="https://github.com/sbarli/innovation-tr/assets/12473529/5d1b457d-c85e-4179-849c-d7aaa65b423c">


## Testing

### Affected tests pass as expected

<img width="418" alt="2023-10-30_21-25-53" src="https://github.com/sbarli/innovation-tr/assets/12473529/fc770153-d398-47b1-984f-9fb338cd6418">

### New Tests Added

<img width="949" alt="2023-10-30_21-26-12" src="https://github.com/sbarli/innovation-tr/assets/12473529/6d929f6e-9338-4a66-9618-eae63089291c">

### Test Coverage

<img width="478" alt="2023-10-30_21-27-08" src="https://github.com/sbarli/innovation-tr/assets/12473529/816e2d7d-53c1-42f1-ac05-eeadcfb101a2">
