### PR TITLE
Feat/be/add timestamps to schemas

### DIFF
--- a/apps/backend/src/games/__mocks__/game.mock.ts
+++ b/apps/backend/src/games/__mocks__/game.mock.ts
@@ -26,6 +26,8 @@ export const MOCK_GAME_INPUT: CreateGameInput = {
 
 export const MOCK_GAME: Game = {
   _id: MOCK_ID,
+  createdAt: undefined,
+  updatedAt: undefined,
   currentActionNumber: 2,
   currentPlayerRef: MOCK_PLAYER_REF_1,
   playerRefs: [MOCK_PLAYER_REF_1, MOCK_PLAYER_REF_2],

--- a/apps/backend/src/games/schemas/game.schema.ts
+++ b/apps/backend/src/games/schemas/game.schema.ts
@@ -7,11 +7,19 @@ import { Deck } from './deck.schema';
 
 export type GameDocument = HydratedDocument<Game>;
 
-@Schema()
+@Schema({ timestamps: true })
 @ObjectType()
 export class Game {
   @Field(() => ID)
   _id!: string;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date;
 
   @Prop({ type: Number, required: true })
   @Field(() => Number)
@@ -51,6 +59,10 @@ export class Game {
 }
 
 @InputType()
-export class CreateGameInput extends OmitType(Game, ['_id', 'winnerRef'] as const, InputType) {}
+export class CreateGameInput extends OmitType(
+  Game,
+  ['_id', 'createdAt', 'updatedAt', 'winnerRef'] as const,
+  InputType
+) {}
 
 export const GameSchema = SchemaFactory.createForClass(Game);

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -211,12 +211,14 @@ type PlayerGameDetails {
   achievements: [ID!]!
   age: Float!
   board: Board!
+  createdAt: DateTime
   gameRef: ID!
   hand: [ID!]!
   playerRef: ID!
   resourceTotals: ResourceTotals!
   score: Float!
   scoreCardRefs: [ID!]!
+  updatedAt: DateTime
 }
 
 type Query {

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -172,10 +172,12 @@ input FindOneOptionsInput {
 type Game {
   _id: ID!
   achievements: Achievements!
+  createdAt: DateTime
   currentActionNumber: Float!
   currentPlayerRef: ID!
   deck: Deck!
   playerRefs: [ID!]!
+  updatedAt: DateTime
   winnerRef: ID
 }
 

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -124,6 +124,11 @@ input CreatePlayersInput {
   names: [String!]!
 }
 
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type Deck {
   EIGHT: [ID!]!
   FIVE: [ID!]!
@@ -195,8 +200,10 @@ type Mutation {
 
 type Player {
   _id: ID!
+  createdAt: DateTime
   name: String!
   playerId: String!
+  updatedAt: DateTime
 }
 
 type PlayerGameDetails {

--- a/apps/backend/src/player-game-details/__mocks__/player-game-details.mock.ts
+++ b/apps/backend/src/player-game-details/__mocks__/player-game-details.mock.ts
@@ -34,6 +34,8 @@ export const MOCK_PLAYER_GAME_DETAILS_INPUT: CreatePlayerGameDetailsInput = {
 
 export const MOCK_PLAYER_GAME_DETAILS: PlayerGameDetails = {
   _id: MOCK_PLAYER_GAME_DETAILS_ID,
+  createdAt: undefined,
+  updatedAt: undefined,
   gameRef: MOCK_GAME_REF,
   playerRef: MOCK_PLAYER_REF,
   age: MOCK_AGE,

--- a/apps/backend/src/player-game-details/schemas/player-game-details.schema.ts
+++ b/apps/backend/src/player-game-details/schemas/player-game-details.schema.ts
@@ -7,11 +7,19 @@ import { Board } from './board.schema';
 
 export type PlayerGameDetailsDocument = HydratedDocument<PlayerGameDetails>;
 
-@Schema()
+@Schema({ timestamps: true })
 @ObjectType()
 export class PlayerGameDetails {
   @Field(() => ID)
   _id!: string;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date;
 
   @Prop({ required: true, type: MongooseSchema.Types.ObjectId, ref: 'Game' })
   @Field(() => ID)
@@ -74,7 +82,7 @@ export class PlayerGameDetails {
 @InputType()
 export class CreatePlayerGameDetailsInput extends OmitType(
   PlayerGameDetails,
-  ['_id'] as const,
+  ['_id', 'createdAt', 'updatedAt'] as const,
   InputType
 ) {}
 

--- a/apps/backend/src/players/__mocks__/player.mock.ts
+++ b/apps/backend/src/players/__mocks__/player.mock.ts
@@ -21,7 +21,13 @@ export const MOCK_PLAYERS_INPUT: CreatePlayersInput = {
   names: [MOCK_PLAYER_NAME, MOCK_PLAYER_NAME_2],
 };
 
-export const MOCK_PLAYER: Player = { _id: MOCK_ID, playerId: MOCK_PLAYER_ID, ...MOCK_PLAYER_INPUT };
+export const MOCK_PLAYER: Player = {
+  ...MOCK_PLAYER_INPUT,
+  _id: MOCK_ID,
+  playerId: MOCK_PLAYER_ID,
+  createdAt: undefined,
+  updatedAt: undefined,
+};
 
 export const MOCK_GET_PLAYER_BY_PLAYER_ID_INPUT: GetPlayerDto = {
   searchField: 'playerId',

--- a/apps/backend/src/players/schemas/player.schema.ts
+++ b/apps/backend/src/players/schemas/player.schema.ts
@@ -4,11 +4,19 @@ import { HydratedDocument } from 'mongoose';
 
 export type PlayerDocument = HydratedDocument<Player>;
 
-@Schema()
+@Schema({ timestamps: true })
 @ObjectType()
 export class Player {
   @Field(() => ID)
   _id!: string;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date;
+
+  @Prop()
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date;
 
   @Prop({ type: String, required: true })
   @Field(() => String)

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -15,6 +15,8 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
+  DateTime: { input: string; output: string; }
 };
 
 export type Achievements = {
@@ -255,8 +257,10 @@ export type MutationUpdatePlayerGameDetailsArgs = {
 export type Player = {
   __typename?: 'Player';
   _id: Scalars['ID']['output'];
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   name: Scalars['String']['output'];
   playerId: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type PlayerGameDetails = {

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -195,10 +195,12 @@ export type Game = {
   __typename?: 'Game';
   _id: Scalars['ID']['output'];
   achievements: Achievements;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   currentActionNumber: Scalars['Float']['output'];
   currentPlayerRef: Scalars['ID']['output'];
   deck: Deck;
   playerRefs: Array<Scalars['ID']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
   winnerRef?: Maybe<Scalars['ID']['output']>;
 };
 
@@ -269,12 +271,14 @@ export type PlayerGameDetails = {
   achievements: Array<Scalars['ID']['output']>;
   age: Scalars['Float']['output'];
   board: Board;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
   gameRef: Scalars['ID']['output'];
   hand: Array<Scalars['ID']['output']>;
   playerRef: Scalars['ID']['output'];
   resourceTotals: ResourceTotals;
   score: Scalars['Float']['output'];
   scoreCardRefs: Array<Scalars['ID']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type Query = {


### PR DESCRIPTION
## Summary

- Satisfies requirements of #51 

- Added `{ timestamps: true }` to `Player`, `Game`, and `PlayerGameDetails` schemas to take advantage of Mongoose's [auto-timestamp functionality](https://mongoosejs.com/docs/timestamps.html)
- Updated mocks to show that `createdAt` and `updatedAt` are available properties, but left them `undefined` for now
- Updated `InputType`s where required to omit the new timestamp fields to prevent these from being set by clients

## Demo

### New documents get `createdAt` set as expected

<img width="1710" alt="image" src="https://github.com/sbarli/innovation-tr/assets/12473529/502f739e-26bd-4a3e-9573-e1ecf529e68e">

### Existing documents get `updatedAt` set as expected, while `createdAt` remains `null`

<img width="1710" alt="image" src="https://github.com/sbarli/innovation-tr/assets/12473529/d956a408-4d0d-430e-b0fd-f09f8a11145f">


## Testing

- [x] All tests still passing (see CI check)