### PR TITLE
Fix/auth/user friendly auth errors display

### DIFF
--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { getCatchErrorMessage } from '@inno/utils';
 import { AccessTokenPayload } from './dto/access-token-payload.dto';
 import { AuthResponse } from './dto/auth.response.dto';
 import { ValidateUserInput } from './dto/validate-user.dto';
+import { isDuplicateKeyError } from './helpers/check-if-duplicate-key-mongo-error';
 import { stripPasswordFromUser } from './helpers/strip-password-from-user';
 import { transformUserToClientUser } from './helpers/transform-user-to-client-user';
 
@@ -73,9 +74,13 @@ export class AuthService {
       };
       return signupResponse;
     } catch (error) {
-      throw new Error(
-        getCatchErrorMessage(error) ?? 'authService.signup -> Unable to signup new user'
+      const failedDueToExistingUser = isDuplicateKeyError(getCatchErrorMessage(error, ''));
+      console.error(
+        failedDueToExistingUser
+          ? `authService.signup -> Unable to signup new user because user already exists with email ${data.email}`
+          : getCatchErrorMessage(error ?? 'authService.signup -> Unable to signup new user')
       );
+      throw new Error('Unable to signup new user');
     }
   }
 
@@ -92,9 +97,8 @@ export class AuthService {
       };
       return loginResponse;
     } catch (error) {
-      throw new Error(
-        getCatchErrorMessage(error) ?? 'authService.signup -> Unable to signup new user'
-      );
+      console.error(getCatchErrorMessage(error ?? 'authService.login -> Unable to login new user'));
+      throw new Error('Unable to login.');
     }
   }
 }

--- a/apps/backend/src/auth/helpers/check-if-duplicate-key-mongo-error.ts
+++ b/apps/backend/src/auth/helpers/check-if-duplicate-key-mongo-error.ts
@@ -1,0 +1,4 @@
+const MONGO_DUPLICATE_KEY_ERROR_CODE = 'E11000';
+
+export const isDuplicateKeyError = (errorMsg: string) =>
+  errorMsg.includes(MONGO_DUPLICATE_KEY_ERROR_CODE);

--- a/apps/backend/src/auth/strategies/jwt.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.ts
@@ -38,9 +38,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       }
       return stripPasswordFromUser(user);
     } catch (error) {
-      throw new UnauthorizedException(
+      console.error(
         getCatchErrorMessage(error) ?? 'JwtStrategy.validate -> Unable to validate user'
       );
+      throw new UnauthorizedException();
     }
   }
 }

--- a/apps/backend/src/auth/strategies/local.strategy.ts
+++ b/apps/backend/src/auth/strategies/local.strategy.ts
@@ -20,7 +20,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(email: string, password: string) {
     const user = await this.authService.validatePassword({ email, password });
     if (!user) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('Login failed');
     }
     return user;
   }

--- a/apps/native/src/authentication/auth.types.ts
+++ b/apps/native/src/authentication/auth.types.ts
@@ -16,7 +16,9 @@ export type TAuthContext = {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (loginData: GetUserInput) => void;
+  loginError?: string;
   signup: (signupData: CreateUserInput) => void;
+  signupError?: string;
   user?: ClientUserData;
 };
 

--- a/apps/native/src/authentication/forms/LoginForm.tsx
+++ b/apps/native/src/authentication/forms/LoginForm.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from '../state/AuthProvider';
 import { loginFormSchema } from '../validation/login-schema';
 
 export const LoginForm = () => {
-  const { login } = useAuthContext();
+  const { login, loginError } = useAuthContext();
   const {
     control,
     handleSubmit,
@@ -90,6 +90,7 @@ export const LoginForm = () => {
       >
         <ButtonText>Submit</ButtonText>
       </Button>
+      <FormError errorMsg={loginError} />
     </Box>
   );
 };

--- a/apps/native/src/authentication/forms/SignupForm.tsx
+++ b/apps/native/src/authentication/forms/SignupForm.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from '../state/AuthProvider';
 import { signupFormSchema } from '../validation/signup-schema';
 
 export const SignupForm = () => {
-  const { signup } = useAuthContext();
+  const { signup, signupError } = useAuthContext();
   const {
     control,
     handleSubmit,
@@ -151,6 +151,7 @@ export const SignupForm = () => {
       >
         <ButtonText>Submit</ButtonText>
       </Button>
+      <FormError errorMsg={signupError} />
     </Box>
   );
 };

--- a/apps/native/src/authentication/helpers/get-graphql-error-message.ts
+++ b/apps/native/src/authentication/helpers/get-graphql-error-message.ts
@@ -1,0 +1,4 @@
+import { ApolloError } from '@apollo/client';
+
+export const getGraphQLErrorMessage = (error: ApolloError, fallback: string = 'Unknown Error') =>
+  error?.graphQLErrors?.[0]?.message ?? fallback;

--- a/apps/native/src/authentication/hooks/useLogin.ts
+++ b/apps/native/src/authentication/hooks/useLogin.ts
@@ -6,7 +6,7 @@ import { Routes } from '../../app-core/constants/navigation';
 import { AuthCallbackFn } from '../auth.types';
 
 export const useLogin = (authCallback: AuthCallbackFn) => {
-  const [loginQuery, { loading }] = useLoginLazyQuery();
+  const [loginQuery, { loading, error }] = useLoginLazyQuery();
 
   const login = async (loginData: GetUserInput) => {
     await loginQuery({
@@ -29,8 +29,7 @@ export const useLogin = (authCallback: AuthCallbackFn) => {
           });
         }
       },
-      onError(error) {
-        console.error('Login Error: ', error);
+      onError() {
         authCallback({
           success: false,
         });
@@ -39,6 +38,7 @@ export const useLogin = (authCallback: AuthCallbackFn) => {
   };
 
   return {
+    error,
     loading,
     login,
   };

--- a/apps/native/src/authentication/hooks/useSIgnup.ts
+++ b/apps/native/src/authentication/hooks/useSIgnup.ts
@@ -6,7 +6,7 @@ import { Routes } from '../../app-core/constants/navigation';
 import { AuthCallbackFn } from '../auth.types';
 
 export const useSignup = (authCallback: AuthCallbackFn) => {
-  const [signupMutation, { loading }] = useSignupMutation();
+  const [signupMutation, { loading, error }] = useSignupMutation();
 
   const signup = async (signupData: CreateUserInput) => {
     signupMutation({
@@ -29,8 +29,7 @@ export const useSignup = (authCallback: AuthCallbackFn) => {
           });
         }
       },
-      onError(error) {
-        console.error('Signup Error: ', error);
+      onError() {
         authCallback({
           success: false,
         });
@@ -39,6 +38,7 @@ export const useSignup = (authCallback: AuthCallbackFn) => {
   };
 
   return {
+    error,
     loading,
     signup,
   };

--- a/apps/native/src/authentication/state/AuthProvider.tsx
+++ b/apps/native/src/authentication/state/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { ClientUserData, useIsAuthenticatedQuery } from '@inno/gql';
 
 import { StorageKeys } from '../../app-core/constants/storage.constants';
 import { TAuthContext, IAuthCallback } from '../auth.types';
+import { getGraphQLErrorMessage } from '../helpers/get-graphql-error-message';
 import { useLogin } from '../hooks/useLogin';
 import { useSignup } from '../hooks/useSIgnup';
 
@@ -58,8 +59,11 @@ export function AuthProvider(props: PropsWithChildren) {
     return true;
   }, []);
 
-  const { loading: loginLoading, login } = useLogin(authCallback);
-  const { loading: signupLoading, signup } = useSignup(authCallback);
+  const { error: loginError, loading: loginLoading, login } = useLogin(authCallback);
+  const { error: signupError, loading: signupLoading, signup } = useSignup(authCallback);
+
+  const signupErrorMessage = signupError ? getGraphQLErrorMessage(signupError) : undefined;
+  const loginErrorMessage = loginError ? getGraphQLErrorMessage(loginError) : undefined;
 
   return (
     <AuthContext.Provider
@@ -68,7 +72,9 @@ export function AuthProvider(props: PropsWithChildren) {
         isLoading:
           isAuthenticated === null || isAuthenticatedLoading || loginLoading || signupLoading,
         login,
+        loginError: loginErrorMessage,
         signup,
+        signupError: signupErrorMessage,
         user,
       }}
     >


### PR DESCRIPTION
## Summary

### Backend

- Updated auth-related error messages to be user-friendly
- Created helper function to determine if MongoDB error is duplicate (aka user already exists)

### RN

- Added error handling logic to auth-related hooks
- Pulled in auth errors and display to user when logging in / signing up

## Demo

### Signup (User already exists)

https://github.com/sbarli/innovation-tr/assets/12473529/832e8982-5843-4aa4-aad7-6271ff73110c

### Login (Invalid password)

https://github.com/sbarli/innovation-tr/assets/12473529/6841dc12-75d0-4ac6-bc8d-cdd37a46a58e
