### PR TITLE
Feat: BE: Add create and leave room logic to socket service

### DIFF
--- a/apps/backend/src/socket/socket.gateway.ts
+++ b/apps/backend/src/socket/socket.gateway.ts
@@ -19,6 +19,7 @@ import { SocketService } from './socket.service';
   },
 })
 export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+  // NOTE: this has to be delcared for websockets to work, but isn't necessary to use 🤷🏼‍♂️
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   @WebSocketServer() private server!: Socket;
@@ -38,9 +39,19 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     return this.socketService.handleConnection(socket);
   }
 
+  @SubscribeMessage('createRoom')
+  createRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
+    return this.socketService.handleCreateRoom(socket, roomId);
+  }
+
   @SubscribeMessage('joinRoom')
   joinRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
     return this.socketService.handleJoinRoom(socket, roomId);
+  }
+
+  @SubscribeMessage('leaveRoom')
+  leaveRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
+    return this.socketService.handleLeaveRoom(socket, roomId);
   }
 
   // Implement other Socket.IO event handlers and message handlers

--- a/apps/backend/src/socket/socket.service.ts
+++ b/apps/backend/src/socket/socket.service.ts
@@ -1,13 +1,95 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Socket } from 'socket.io';
 
 import { getCatchErrorMessage } from '@inno/utils';
+
+export type Room = {
+  roomId: string;
+  host: string;
+  clientsInRoom: string[];
+};
 
 @Injectable()
 export class SocketService {
   private logger: Logger = new Logger('SocketService');
   private readonly connectedClients: Map<string, Socket> = new Map();
+  private readonly rooms: Map<string, Room> = new Map();
 
+  /**
+   * @name handleDisconnectedRoomHost
+   * @description handles room where the disconnected user was the host
+   *  if user was the only remaining client in the room, delete the room
+   *  otherwise, make next client in room the host
+   */
+  handleDisconnectedRoomHost(socket: Socket, roomId: string, room?: Room) {
+    const roomData = room ?? this.rooms.get(roomId);
+    if (!roomData) {
+      this.logger.warn(`could not remove ${socket.id} as host of room ${roomId}: room not found`);
+      return;
+    }
+    const remainingClientsInRoom = roomData.clientsInRoom.filter(
+      (clientId) => clientId !== socket.id
+    );
+    if (remainingClientsInRoom.length) {
+      this.rooms.set(roomId, {
+        ...roomData,
+        host: remainingClientsInRoom[0],
+        clientsInRoom: remainingClientsInRoom,
+      });
+      socket.to(roomId).emit('hostLeftRoomNewHostAssigned', {
+        oldHost: socket.id,
+        newHost: remainingClientsInRoom[0],
+      });
+      return;
+    }
+    this.rooms.delete(roomId);
+    return;
+  }
+
+  /**
+   * @name handleDisconnectedRoomGuest
+   * @description handles removing user as a client in a room
+   */
+  handleDisconnectedRoomGuest(socket: Socket, roomId: string, room?: Room) {
+    const roomData = room ?? this.rooms.get(roomId);
+    if (!roomData) {
+      this.logger.warn(`could not remove ${socket.id} from room ${roomId}: room not found`);
+      return;
+    }
+    const remainingClientsInRoom = roomData.clientsInRoom.filter(
+      (clientId) => clientId !== socket.id
+    );
+    this.rooms.set(roomId, {
+      ...roomData,
+      clientsInRoom: remainingClientsInRoom,
+    });
+    socket.to(roomId).emit('userLeftRoom', {
+      clientId: socket.id,
+    });
+    return;
+  }
+
+  /**
+   * @name handleRemoveDisconnectedUserFromAllRooms
+   * @description handles removing disconnected users from all rooms they are connected to
+   *  if they are host, calls @handleDisconnectedRoomHost to handlee new host logic
+   *  otherwise, simply removes the user from the room client list
+   */
+  handleRemoveDisconnectedUserFromAllRooms(socket: Socket) {
+    this.rooms.forEach((room, roomId) => {
+      if (room.host === socket.id) {
+        return this.handleDisconnectedRoomHost(socket, roomId, room);
+      }
+      if (room.clientsInRoom.includes(socket.id)) {
+        return this.handleDisconnectedRoomGuest(socket, roomId, room);
+      }
+    });
+  }
+
+  /**
+   * @name handleConnection
+   * @description handles storing connected clients and diconnect logic
+   */
   handleConnection(socket: Socket): void {
     const clientId = socket.id;
     this.logger.log(`Client connected: ${clientId}`);
@@ -15,23 +97,89 @@ export class SocketService {
 
     socket.on('disconnect', () => {
       this.logger.log(`handling disconnect for ${clientId}`);
+      this.handleRemoveDisconnectedUserFromAllRooms(socket);
       this.connectedClients.delete(clientId);
     });
   }
 
-  handleJoinRoom(socket: Socket, roomId: string) {
+  /**
+   * @name handleCreateRoom
+   * @description creats a new room if room does not currently exist
+   */
+  handleCreateRoom(socket: Socket, roomId: string) {
     try {
+      if (this.rooms.has(roomId)) {
+        this.logger.error(`could not create room with id ${roomId}: Room already exists`);
+        throw new Error(`could not create room with id ${roomId}: Room already exists`);
+      }
+      this.rooms.set(roomId, { roomId, host: socket.id, clientsInRoom: [] });
+      return this.handleJoinRoom(socket, roomId, true);
+    } catch (error) {
+      const errorMessage =
+        getCatchErrorMessage(error) ??
+        `handleCreateRoom: Unable to create room ${roomId} for socket user ${socket.id}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
+   * @name handleJoinRoom
+   * @description handles adding socket to existing room and notifying existing clients of the new member
+   */
+  handleJoinRoom(socket: Socket, roomId: string, newRoom: boolean = false) {
+    try {
+      const roomData = this.rooms.get(roomId);
+      if (!roomData) {
+        this.logger.error(`${socket.id} could not join room with id ${roomId}: Room not found`);
+        throw new NotFoundException(`Room ${roomId} not found`);
+      }
       if (socket.rooms.has(roomId)) {
         this.logger.warn(`${socket.id} already in room ${roomId}`);
         return { event: 'socketInRoom', roomId };
       }
+      this.rooms.set(roomId, {
+        ...roomData,
+        clientsInRoom: [...roomData.clientsInRoom, socket.id],
+      });
       socket.join(roomId);
+      if (newRoom) {
+        socket.to(roomId).emit('roomCreated');
+      }
       socket.to(roomId).emit('userJoinedRoom', { clientId: socket.id });
       return { event: 'roomJoined', roomId };
     } catch (error) {
       const errorMessage =
-        getCatchErrorMessage(error) ??
-        `handleJoinRoom: Unable to join room for socket user ${socket.id}`;
+        getCatchErrorMessage(error) ?? `Unable to join room for socket user ${socket.id}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
+   * @name handleLeaveRoom
+   * @description removes socket from room and handles calling proper helper to update local room storage data
+   */
+  handleLeaveRoom(socket: Socket, roomId: string) {
+    try {
+      const roomData = this.rooms.get(roomId);
+      if (!roomData) {
+        this.logger.error(`${roomId}: Room not found`);
+        throw new NotFoundException(`Room ${roomId} not found`);
+      }
+      if (!socket.rooms.has(roomId)) {
+        this.logger.error(`${socket.id} is not in room ${roomId}`);
+        throw new Error(`${socket.id} is already not in room ${roomId}`);
+      }
+      socket.leave(roomId);
+      if (roomData.host == socket.id) {
+        return this.handleDisconnectedRoomHost(socket, roomId, roomData);
+      }
+      this.handleDisconnectedRoomGuest(socket, roomId, roomData);
+      return { event: 'leftRoom', roomId };
+    } catch (error) {
+      const errorMessage =
+        getCatchErrorMessage(error) ?? `Unable to leave room for socket user ${socket.id}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
     }


### PR DESCRIPTION
## Summary

- Adds logic to create a new room and leave an existing room
- includes new internal state for room data

## Demo

| User No | Demo |
| --- | --- |
| User 1 | ![2024-01-19_19-23-40](https://github.com/sbarli/innovation-tr/assets/12473529/0a954284-c506-4a55-af2b-c5cd2256b896) |
| User 2 | ![2024-01-19_19-23-57](https://github.com/sbarli/innovation-tr/assets/12473529/2f8b3ef5-aa1e-46fc-8f51-c040fced2f50) |
| User 3 | ![2024-01-19_19-24-15](https://github.com/sbarli/innovation-tr/assets/12473529/d83897fa-4fa0-4455-be0f-546ad8dc683e) |


## Testing

Separate Issue to address testing web sockets

### Test Coverage