### PR TITLE
Chore: Repo: Update configs and doppler setup

### DIFF
--- a/apps/native/app.config.ts
+++ b/apps/native/app.config.ts
@@ -4,12 +4,10 @@ const APP_NAME = 'Innovation';
 const APP_ORIENTATION = 'landscape';
 const APP_SLUG = 'innovation';
 const APP_VERSION = {
-  major: 1,
-  minor: 0,
+  major: 0,
+  minor: 1,
   fix: 0,
 };
-const EXPO_PROJECT_ID = 'ea3d151c-beca-4db0-a089-268fbbe3d3ea';
-const EXPO_OWNER_HANDLE = 'sbarli';
 
 const getAppVersion = () => `${APP_VERSION.major}.${APP_VERSION.minor}.${APP_VERSION.fix}`;
 
@@ -22,9 +20,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: APP_ORIENTATION,
   extra: {
     eas: {
-      projectId: EXPO_PROJECT_ID,
+      projectId: process.env['EXPO_PUBLIC_PROJECT_ID'] ?? '',
     },
   },
-  owner: EXPO_OWNER_HANDLE,
+  owner: process.env['EXPO_PUBLIC_OWNER_HANDLE'] ?? '',
   plugins: ['expo-router'],
 });

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inno/native",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "index.js",
   "scripts": {
     "start": "doppler run -- expo start",

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,13 +4,13 @@ module.exports = {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       // Transform all direct `react-native` imports to `react-native-web`
-      "react-native$": "react-native-web",
+      'react-native$': 'react-native-web',
     };
     config.resolve.extensions = [
-      ".web.js",
-      ".web.jsx",
-      ".web.ts",
-      ".web.tsx",
+      '.web.js',
+      '.web.jsx',
+      '.web.ts',
+      '.web.tsx',
       ...config.resolve.extensions,
     ];
     return config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inno/web",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,7 +1,8 @@
 setup:
-  - project: innovation
-    config: dev_backend
-    path: ./apps/backend/
-  - project: innovation
-    config: dev_native
+  - project: native
+    config: dev
     path: ./apps/native/
+  - project: backend
+    config: dev
+    path: ./apps/backend/
+  


### PR DESCRIPTION
## Summary

- even though expo project and owner are public, moved them to Doppler for consistency
- updated Doppler project setup to match best practices per docs

## Demo

### BE still runs
<img width="929" alt="2024-01-20_12-34-09" src="https://github.com/sbarli/innovation/assets/12473529/597ceebc-f5b3-4691-a78f-3eb8175de118">

### RN still runs

<img width="871" alt="2024-01-20_12-33-01" src="https://github.com/sbarli/innovation/assets/12473529/da233d12-1b53-42c2-a6f5-06d305adacdf">

