### PR TITLE
Chore: BE: Update websocket response emits

### DIFF
--- a/apps/backend/src/socket/socket.gateway.ts
+++ b/apps/backend/src/socket/socket.gateway.ts
@@ -11,6 +11,8 @@ import {
 } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
 
+import { SocketEvent } from '@inno/constants';
+
 import { SocketService } from './socket.service';
 
 @WebSocketGateway({
@@ -39,17 +41,17 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     return this.socketService.handleConnection(socket);
   }
 
-  @SubscribeMessage('createRoom')
+  @SubscribeMessage(SocketEvent.CREATE_ROOM)
   createRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
     return this.socketService.handleCreateRoom(socket, roomId);
   }
 
-  @SubscribeMessage('joinRoom')
+  @SubscribeMessage(SocketEvent.JOIN_ROOM)
   joinRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
     return this.socketService.handleJoinRoom(socket, roomId);
   }
 
-  @SubscribeMessage('leaveRoom')
+  @SubscribeMessage(SocketEvent.LEAVE_ROOM)
   leaveRoom(@MessageBody('roomId') roomId: string, @ConnectedSocket() socket: Socket) {
     return this.socketService.handleLeaveRoom(socket, roomId);
   }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inno/constants",
-  "version": "1.2.0",
+  "version": "2.2.0",
   "description": "shared constants",
   "author": "Samantha Barli",
   "private": true,

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,2 +1,3 @@
 export * from './cards';
 export * from './players';
+export * from './sockets';

--- a/packages/constants/src/sockets.ts
+++ b/packages/constants/src/sockets.ts
@@ -1,0 +1,28 @@
+export enum SocketEventErrorCode {
+  DUPE = 50,
+  UNKNOWN = 100,
+}
+
+export type SocketEventError = {
+  errorCode: SocketEventErrorCode;
+  message: string;
+};
+
+export enum SocketEvent {
+  // server-emitted events
+  ALREADY_IN_ROOM = 'alreadyInRoom',
+  CREATE_ROOM_ERROR = 'createRoomError',
+  CREATE_ROOM_SUCCESS = 'createRoomSuccess',
+  LEFT_ROOM = 'leftRoom',
+  ROOM_JOINED = 'roomJoined',
+
+  // client-Emitted Events
+  CREATE_ROOM = 'createRoom',
+  JOIN_ROOM = 'joinRoom',
+  LEAVE_ROOM = 'leaveRoom',
+
+  // event emitted to rooms
+  HOST_LEFT_ROOM_NEW_HOST_ASSIGNED = 'hostLeftRoomNewHostAssigned',
+  USER_JOINED_ROOM = 'userJoinedRoom',
+  USER_LEFT_ROOM = 'userLeftRoom',
+}


### PR DESCRIPTION
## Summary

- use types from constants package for future sharing with client apps
- use `emit` instead of `return` for event response data
