### PR TITLE
Feat: Rooms: Add error handling for existing room

### DIFF
--- a/apps/native/src/rooms/forms/JoinRoomForm.tsx
+++ b/apps/native/src/rooms/forms/JoinRoomForm.tsx
@@ -4,7 +4,7 @@ import { Box, Button, ButtonText, Input, InputField } from '@gluestack-ui/themed
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
 
-import { SocketEvent } from '@inno/constants';
+import { SocketEvent, SocketEventError } from '@inno/constants';
 
 import { FormError } from '../../app-core/forms/FormError';
 import { socket } from '../../websockets/socket';
@@ -34,13 +34,13 @@ export const JoinRoomForm = ({ onJoinSuccess }: IJoinRoomFormProps) => {
   };
 
   useEffect(() => {
-    socket.on(SocketEvent.ALREADY_IN_ROOM, () => {
+    socket.on(SocketEvent.JOIN_ROOM_ERROR, (error: SocketEventError) => {
       setError('roomId', {
         type: 'custom',
-        message: 'You are already in this room!',
+        message: error.message,
       });
     });
-    socket.on(SocketEvent.ROOM_JOINED, (roomId: string) => {
+    socket.on(SocketEvent.JOIN_ROOM_SUCCESS, (roomId: string) => {
       onJoinSuccess(roomId);
     });
   }, [socket]);

--- a/packages/constants/src/sockets.ts
+++ b/packages/constants/src/sockets.ts
@@ -1,20 +1,25 @@
 export enum SocketEventErrorCode {
   DUPE = 50,
+  NOT_FOUND = 75,
   UNKNOWN = 100,
 }
 
-export type SocketEventError = {
-  errorCode: SocketEventErrorCode;
-  message: string;
-};
+export class SocketEventError {
+  constructor(
+    public errorCode: SocketEventErrorCode,
+    public message: string,
+    public data?: unknown
+  ) {}
+}
 
 export enum SocketEvent {
   // server-emitted events
-  ALREADY_IN_ROOM = 'alreadyInRoom',
   CREATE_ROOM_ERROR = 'createRoomError',
   CREATE_ROOM_SUCCESS = 'createRoomSuccess',
-  LEFT_ROOM = 'leftRoom',
-  ROOM_JOINED = 'roomJoined',
+  JOIN_ROOM_ERROR = 'joinRoomError',
+  JOIN_ROOM_SUCCESS = 'joinRoomSuccess',
+  LEAVE_ROOM_SUCCESS = 'leaveRoomSuccess',
+  LEAVE_ROOM_ERROR = 'leaveRoomError',
 
   // client-Emitted Events
   CREATE_ROOM = 'createRoom',


### PR DESCRIPTION
## Summary

- Adds proper socket even emission when user attempts to create a room that already exists
- Updates event error types and process for consistency
- Adds more catches on RN to display errors if/when they are emitted
- Satisfies requirements of #77 

## Demo
![2024-01-21_14-28-51](https://github.com/sbarli/innovation/assets/12473529/3fed326c-48af-4239-8728-a1bc20416eed)
![2024-01-21_14-26-05](https://github.com/sbarli/innovation/assets/12473529/1f6db4a9-cf45-44d2-80c2-993a620083a1)
![2024-01-21_14-25-48](https://github.com/sbarli/innovation/assets/12473529/6fbb8f61-823a-4fd0-ae5d-31d4cc241252)
