### PR TITLE
Feat/rooms/refactor

### DIFF
--- a/apps/backend/src/auth/helpers/strip-password-from-user.ts
+++ b/apps/backend/src/auth/helpers/strip-password-from-user.ts
@@ -2,7 +2,7 @@ import { User, UserWithoutPassword } from 'src/users/schemas/user.schema';
 
 export const stripPasswordFromUser = (user: User): UserWithoutPassword => ({
   _id: user._id,
-  displayName: user.displayName,
+  username: user.username,
   email: user.email,
   createdAt: user.createdAt,
   updatedAt: user.updatedAt,

--- a/apps/backend/src/auth/helpers/transform-user-to-client-user.ts
+++ b/apps/backend/src/auth/helpers/transform-user-to-client-user.ts
@@ -2,6 +2,6 @@ import { ClientUserData, User, UserWithoutPassword } from 'src/users/schemas/use
 
 export const transformUserToClientUser = (user: User | UserWithoutPassword): ClientUserData => ({
   _id: user._id,
-  displayName: user.displayName,
+  username: user.username,
   email: user.email,
 });

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -102,8 +102,8 @@ type CardRefsByAge {
 
 type ClientUserData {
   _id: ID!
-  displayName: String!
   email: String!
+  username: String!
 }
 
 input CreateNewGameInput {
@@ -132,9 +132,9 @@ input CreateRoomInput {
 }
 
 input CreateUserInput {
-  displayName: String!
   email: String!
   password: String!
+  username: String!
 }
 
 """
@@ -266,10 +266,10 @@ input ResourceTotalsInput {
 type Room {
   _id: ID!
   availableToJoin: Boolean!
-  connectedPlayerRefs: [ID!]!
   createdAt: DateTime
   hostRef: ID!
   name: String!
+  playerRefs: [ID!]!
   updatedAt: DateTime
 }
 

--- a/apps/backend/src/rooms/__mocks__/room.mock.ts
+++ b/apps/backend/src/rooms/__mocks__/room.mock.ts
@@ -16,12 +16,12 @@ export const MOCK_NEW_ROOM: Room = {
   updatedAt: undefined,
   name: MOCK_ROOM_NAME,
   hostRef: MOCK_USER_ID,
-  connectedPlayerRefs: [],
+  playerRefs: [],
   availableToJoin: true,
 };
 
 export const MOCK_CLOSED_ROOM: Room = {
   ...MOCK_NEW_ROOM,
-  connectedPlayerRefs: [MOCK_USER_ID_2],
+  playerRefs: [MOCK_USER_ID_2],
   availableToJoin: false,
 };

--- a/apps/backend/src/rooms/schemas/room.schema.ts
+++ b/apps/backend/src/rooms/schemas/room.schema.ts
@@ -32,7 +32,7 @@ export class Room {
     ref: 'User',
   })
   @Field(() => [ID])
-  connectedPlayerRefs!: string[];
+  playerRefs!: string[];
 
   @Prop({ required: true, default: true, type: Boolean })
   @Field(() => Boolean)

--- a/apps/backend/src/socket/socket.gateway.ts
+++ b/apps/backend/src/socket/socket.gateway.ts
@@ -55,13 +55,35 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   }
 
   @UseGuards(JwtWsAuthGuard)
+  @SubscribeMessage(SocketEvent.GET_PLAYER_ROOMS_OVERVIEW)
+  async getPlayerRoomsOverview(
+    @CurrentUserFromRequest() user: UserWithoutPassword,
+    @ConnectedSocket() socket: Socket
+  ) {
+    return this.socketService.handleGetPlayerRoomsOverview(socket, {
+      socketServer: this.server,
+      user,
+    });
+  }
+
+  @UseGuards(JwtWsAuthGuard)
   @SubscribeMessage(SocketEvent.LEAVE_ROOM)
   leaveRoom(
     @CurrentUserFromRequest() user: UserWithoutPassword,
     @MessageBody('roomId') roomId: string,
     @ConnectedSocket() socket: Socket
   ) {
-    return this.socketService.handleLeaveRoom(socket, { roomId, user });
+    return this.socketService.handleLeaveRoom(socket, { roomId, socketServer: this.server, user });
+  }
+
+  @UseGuards(JwtWsAuthGuard)
+  @SubscribeMessage(SocketEvent.CLOSE_ROOM)
+  closeRoom(
+    @CurrentUserFromRequest() user: UserWithoutPassword,
+    @MessageBody('roomId') roomId: string,
+    @ConnectedSocket() socket: Socket
+  ) {
+    return this.socketService.handleCloseRoom(socket, { roomId, socketServer: this.server, user });
   }
 
   // Implement other Socket.IO event handlers and message handlers

--- a/apps/backend/src/users/__mocks__/user.mock.ts
+++ b/apps/backend/src/users/__mocks__/user.mock.ts
@@ -11,7 +11,7 @@ export const MOCK_USER_PASSWORD = 'mock@userpass1';
 export const MOCK_CREATE_USER_INPUT: CreateUserInput = {
   email: MOCK_USER_EMAIL,
   password: MOCK_USER_PASSWORD,
-  displayName: MOCK_USER_DISPLAY_NAME,
+  username: MOCK_USER_DISPLAY_NAME,
 };
 
 export const MOCK_GET_USER_INPUT: GetUserInput = {
@@ -29,7 +29,7 @@ export const MOCK_USER: User = {
 export const MOCK_USER_WITHOUT_PASSWORD: UserWithoutPassword = {
   _id: MOCK_USER_ID,
   email: MOCK_USER_EMAIL,
-  displayName: MOCK_USER_DISPLAY_NAME,
+  username: MOCK_USER_DISPLAY_NAME,
   createdAt: undefined,
   updatedAt: undefined,
 };
@@ -37,5 +37,5 @@ export const MOCK_USER_WITHOUT_PASSWORD: UserWithoutPassword = {
 export const MOCK_USER_CLIENT_DATA: ClientUserData = {
   _id: MOCK_USER_ID,
   email: MOCK_USER_EMAIL,
-  displayName: MOCK_USER_DISPLAY_NAME,
+  username: MOCK_USER_DISPLAY_NAME,
 };

--- a/apps/backend/src/users/dto/create-user.dto.ts
+++ b/apps/backend/src/users/dto/create-user.dto.ts
@@ -10,5 +10,5 @@ export class CreateUserInput {
   password!: string;
 
   @Field(() => String)
-  displayName!: string;
+  username!: string;
 }

--- a/apps/backend/src/users/schemas/user.schema.ts
+++ b/apps/backend/src/users/schemas/user.schema.ts
@@ -20,7 +20,7 @@ export class User {
 
   @Prop({ type: String, required: true })
   @Field(() => String)
-  displayName!: string;
+  username!: string;
 
   @Prop({ type: String, required: true, unique: true, index: true })
   @Field(() => String)

--- a/apps/native/app/(app)/rooms/[roomId]/index.tsx
+++ b/apps/native/app/(app)/rooms/[roomId]/index.tsx
@@ -2,7 +2,7 @@ import { useLocalSearchParams } from 'expo-router';
 
 import { useGetRoomQuery } from '@inno/gql';
 
-import { HeaderWithBackNavigation } from '../../../../src/app-core/components/headers/HeaderWithBackNavigation';
+import { HeaderNoNav } from '../../../../src/app-core/components/headers/HeaderNoNav';
 import { RoomScreen } from '../../../../src/rooms/screens/RoomScreen';
 
 // eslint-disable-next-line import/no-default-export
@@ -18,7 +18,7 @@ export default function Room() {
   });
   return (
     <>
-      <HeaderWithBackNavigation title={data?.getRoom?.name ?? '...'} />
+      <HeaderNoNav title={data?.getRoom?.name ?? '...'} />
       <RoomScreen roomData={data?.getRoom} loading={loading} error={error} />
     </>
   );

--- a/apps/native/src/authentication/auth.types.ts
+++ b/apps/native/src/authentication/auth.types.ts
@@ -6,7 +6,7 @@ export type LoginFormData = {
 };
 
 export type SignupFormData = {
-  displayName: string;
+  username: string;
   email: string;
   password: string;
   passwordConfirm: string;

--- a/apps/native/src/authentication/forms/SignupForm.tsx
+++ b/apps/native/src/authentication/forms/SignupForm.tsx
@@ -15,7 +15,7 @@ export const SignupForm = () => {
     formState: { errors },
   } = useForm<SignupFormData>({
     defaultValues: {
-      displayName: '',
+      username: '',
       email: '',
       password: '',
       passwordConfirm: '',
@@ -24,7 +24,7 @@ export const SignupForm = () => {
   });
   const onSubmit = (data: SignupFormData) => {
     signup({
-      displayName: data.displayName,
+      username: data.username,
       email: data.email,
       password: data.password,
     });
@@ -34,7 +34,7 @@ export const SignupForm = () => {
       <Box marginBottom="$5">
         <Controller
           control={control}
-          name="displayName"
+          name="username"
           rules={{
             required: true,
           }}
@@ -43,7 +43,7 @@ export const SignupForm = () => {
               variant="outline"
               size="md"
               isDisabled={false}
-              isInvalid={!!errors.displayName}
+              isInvalid={!!errors.username}
               isReadOnly={false}
             >
               <InputField
@@ -55,7 +55,7 @@ export const SignupForm = () => {
             </Input>
           )}
         />
-        <FormError errorMsg={errors.displayName?.message} />
+        <FormError errorMsg={errors.username?.message} />
       </Box>
 
       <Box marginBottom="$5">

--- a/apps/native/src/authentication/validation/signup-schema.ts
+++ b/apps/native/src/authentication/validation/signup-schema.ts
@@ -10,7 +10,7 @@ const passwordValidation = z
 
 export const signupFormSchema: ZodType<SignupFormData> = z
   .object({
-    displayName: z
+    username: z
       .string()
       .min(3)
       .max(20)

--- a/apps/native/src/rooms/components/RoomCard.tsx
+++ b/apps/native/src/rooms/components/RoomCard.tsx
@@ -20,6 +20,7 @@ import { RoomDataFragment } from '@inno/gql';
 
 export interface IRoomMetadata {
   userIsHost: boolean;
+  playersInRoom?: number;
 }
 
 export interface IRoomCardProps {
@@ -67,7 +68,9 @@ export const RoomCard = ({ metadata, room, socket }: IRoomCardProps) => {
         {metadata.userIsHost ? <Text>Room ID: {room._id}</Text> : null}
         {/* TODO: make this host username */}
         <Text>Host: {room.hostRef}</Text>
-        <Text>Players in room: {room.connectedPlayerRefs.length + 1}</Text>
+        {metadata.playersInRoom !== undefined ? (
+          <Text>Players in room: {metadata.playersInRoom}</Text>
+        ) : null}
         <HStack space="md" justifyContent="flex-end">
           {metadata.userIsHost ? (
             // TODO: add close room logic

--- a/apps/native/src/rooms/room.types.ts
+++ b/apps/native/src/rooms/room.types.ts
@@ -1,3 +1,8 @@
+export interface IPlayersInRoom {
+  roomId: string;
+  playersInRoom: number;
+}
+
 export type CreateRoomFormData = {
   roomName: string;
 };

--- a/packages/constants/src/sockets.ts
+++ b/packages/constants/src/sockets.ts
@@ -14,14 +14,19 @@ export class SocketEventError {
 
 export enum SocketEvent {
   // server-emitted events
+  CLOSE_ROOM_ERROR = 'closeRoomError',
+  CLOSE_ROOM_SUCCESS = 'closeRoomSuccess',
   CREATE_ROOM_ERROR = 'createRoomError',
   CREATE_ROOM_SUCCESS = 'createRoomSuccess',
+  GET_PLAYER_ROOMS_OVERVIEW_ERROR = 'getPlayerRoomsOverviewError',
   JOIN_ROOM_ERROR = 'joinRoomError',
   JOIN_ROOM_SUCCESS = 'joinRoomSuccess',
   LEAVE_ROOM_SUCCESS = 'leaveRoomSuccess',
   LEAVE_ROOM_ERROR = 'leaveRoomError',
 
   // client-Emitted Events
+  CLOSE_ROOM = 'closeRoom',
+  GET_PLAYER_ROOMS_OVERVIEW = 'getPlayerRoomsOverview',
   JOIN_ROOM = 'joinRoom',
   LEAVE_ROOM = 'leaveRoom',
 

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -128,8 +128,8 @@ export type CardRefsByAge = {
 export type ClientUserData = {
   __typename?: 'ClientUserData';
   _id: Scalars['ID']['output'];
-  displayName: Scalars['String']['output'];
   email: Scalars['String']['output'];
+  username: Scalars['String']['output'];
 };
 
 export type CreateNewGameInput = {
@@ -159,9 +159,9 @@ export type CreateRoomInput = {
 };
 
 export type CreateUserInput = {
-  displayName: Scalars['String']['input'];
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+  username: Scalars['String']['input'];
 };
 
 export type Deck = {
@@ -365,10 +365,10 @@ export type Room = {
   __typename?: 'Room';
   _id: Scalars['ID']['output'];
   availableToJoin: Scalars['Boolean']['output'];
-  connectedPlayerRefs: Array<Scalars['ID']['output']>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
   hostRef: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  playerRefs: Array<Scalars['ID']['output']>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
@@ -401,26 +401,26 @@ export type UpdateRoomAvailabilityInput = {
   roomId: Scalars['String']['input'];
 };
 
-export type AuthResponseDataFragment = { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, displayName: string, email: string } };
+export type AuthResponseDataFragment = { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, username: string, email: string } };
 
 export type IsAuthenticatedQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type IsAuthenticatedQuery = { __typename?: 'Query', isAuthenticated: { __typename?: 'ClientUserData', _id: string, displayName: string, email: string } };
+export type IsAuthenticatedQuery = { __typename?: 'Query', isAuthenticated: { __typename?: 'ClientUserData', _id: string, username: string, email: string } };
 
 export type LoginQueryVariables = Exact<{
   loginUserInput: GetUserInput;
 }>;
 
 
-export type LoginQuery = { __typename?: 'Query', login: { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, displayName: string, email: string } } };
+export type LoginQuery = { __typename?: 'Query', login: { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, username: string, email: string } } };
 
 export type SignupMutationVariables = Exact<{
   newUserData: CreateUserInput;
 }>;
 
 
-export type SignupMutation = { __typename?: 'Mutation', signup: { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, displayName: string, email: string } } };
+export type SignupMutation = { __typename?: 'Mutation', signup: { __typename?: 'AuthResponse', access_token: string, user: { __typename?: 'ClientUserData', _id: string, username: string, email: string } } };
 
 export type BaseCardFragment = { __typename?: 'Card', _id: string, cardId: string, name: string, age: string, color: string, dogmaResource: string };
 
@@ -440,35 +440,35 @@ export type CreateRoomMutationVariables = Exact<{
 }>;
 
 
-export type CreateRoomMutation = { __typename?: 'Mutation', createRoom: { __typename?: 'Room', _id: string, name: string, hostRef: string, connectedPlayerRefs: Array<string>, availableToJoin: boolean } };
+export type CreateRoomMutation = { __typename?: 'Mutation', createRoom: { __typename?: 'Room', _id: string, name: string, hostRef: string, playerRefs: Array<string>, availableToJoin: boolean } };
 
-export type RoomDataFragment = { __typename?: 'Room', _id: string, name: string, hostRef: string, connectedPlayerRefs: Array<string>, availableToJoin: boolean };
+export type RoomDataFragment = { __typename?: 'Room', _id: string, name: string, hostRef: string, playerRefs: Array<string>, availableToJoin: boolean };
 
 export type GetRoomQueryVariables = Exact<{
   roomId: Scalars['String']['input'];
 }>;
 
 
-export type GetRoomQuery = { __typename?: 'Query', getRoom?: { __typename?: 'Room', _id: string, name: string, hostRef: string, connectedPlayerRefs: Array<string>, availableToJoin: boolean } | null };
+export type GetRoomQuery = { __typename?: 'Query', getRoom?: { __typename?: 'Room', _id: string, name: string, hostRef: string, playerRefs: Array<string>, availableToJoin: boolean } | null };
 
 export type GetRoomsForPlayerQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetRoomsForPlayerQuery = { __typename?: 'Query', getRoomsForPlayer?: Array<{ __typename?: 'Room', _id: string, name: string, hostRef: string, connectedPlayerRefs: Array<string>, availableToJoin: boolean }> | null };
+export type GetRoomsForPlayerQuery = { __typename?: 'Query', getRoomsForPlayer?: Array<{ __typename?: 'Room', _id: string, name: string, hostRef: string, playerRefs: Array<string>, availableToJoin: boolean }> | null };
 
 export type UpdateRoomAvailabilityMutationVariables = Exact<{
   data: UpdateRoomAvailabilityInput;
 }>;
 
 
-export type UpdateRoomAvailabilityMutation = { __typename?: 'Mutation', updateRoomAvailability?: { __typename?: 'Room', _id: string, name: string, hostRef: string, connectedPlayerRefs: Array<string>, availableToJoin: boolean } | null };
+export type UpdateRoomAvailabilityMutation = { __typename?: 'Mutation', updateRoomAvailability?: { __typename?: 'Room', _id: string, name: string, hostRef: string, playerRefs: Array<string>, availableToJoin: boolean } | null };
 
-export type UserDetailsFragment = { __typename?: 'ClientUserData', _id: string, displayName: string, email: string };
+export type UserDetailsFragment = { __typename?: 'ClientUserData', _id: string, username: string, email: string };
 
 export const UserDetailsFragmentDoc = gql`
     fragment UserDetails on ClientUserData {
   _id
-  displayName
+  username
   email
 }
     `;
@@ -529,7 +529,7 @@ export const RoomDataFragmentDoc = gql`
   _id
   name
   hostRef
-  connectedPlayerRefs
+  playerRefs
   availableToJoin
 }
     `;

--- a/packages/gql/src/rooms/fragments/room.fragment.gql
+++ b/packages/gql/src/rooms/fragments/room.fragment.gql
@@ -2,6 +2,6 @@ fragment RoomData on Room {
   _id
   name
   hostRef
-  connectedPlayerRefs
+  playerRefs
   availableToJoin
 }

--- a/packages/gql/src/users/fragments/user.fragment.gql
+++ b/packages/gql/src/users/fragments/user.fragment.gql
@@ -1,5 +1,5 @@
 fragment UserDetails on ClientUserData {
   _id
-  displayName
+  username
   email
 }


### PR DESCRIPTION
## Summary

Refactored logic of rooms:
- connected players data stays in WebSocket land
- players _allowed_ to connect is stored in RoomsService (mongo)
- updated leave room logic so that it just removes the connected socket from the room
- added new close room handlers on sockets & rooms services (not yet hooked up on FE)

## Demo


https://github.com/sbarli/innovation/assets/12473529/367cb06a-598f-42b8-affb-f576e049ffa7

