### PR TITLE
Chore/rn/cleanup rooms ux

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # lint the repo
-yarn turbo run lint:fix --filter="[HEAD^1]" --filter=@inno/gql
+yarn turbo run lint:fix --filter="[HEAD^1]"
 
 # test the repo
-yarn turbo run test --filter="[HEAD^1]" --filter=@inno/gql
+yarn turbo run test --filter="[HEAD^1]"

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -135,9 +135,14 @@ export class RoomsService {
         throw new Error('RoomsService.addPlayerToRoom -> Too many players in room');
       }
 
+      // otherwise, update room with new player
       const updateData: Partial<Room> = { playerRefs: [...room.playerRefs, playerRef] };
 
-      // otherwise, update room with new player
+      // if player is the last allowed to join, close the room
+      if (CURRENT_PLAYER_COUNT + 1 === MAX_USERS_PER_ROOM) {
+        updateData.availableToJoin = false;
+      }
+
       return this.roomModel.findByIdAndUpdate(roomId, updateData, { new: true });
     } catch (error) {
       throw new Error(

--- a/apps/backend/src/socket/services/socket-room.service.ts
+++ b/apps/backend/src/socket/services/socket-room.service.ts
@@ -62,16 +62,11 @@ export class SocketRoomService {
           error: errorData,
         });
       }
-      const roomIsOpen = room.availableToJoin;
       const userIsRoomMember = room.playerRefs
         .map((ref) => ref.toString())
         .includes(user._id.toString());
-      if (!roomIsOpen || !userIsRoomMember) {
-        this.logger.error(
-          `${user._id} could not join room ${roomId}: ${
-            !roomIsOpen ? 'Room is closed' : 'User is not member of room'
-          }`
-        );
+      if (!userIsRoomMember) {
+        this.logger.error(`${user._id} could not join room ${roomId}: User is not member of room`);
         const errorData = new SocketEventError(SocketEventErrorCode.INVALID, 'User cannot join', {
           roomId,
         });

--- a/apps/backend/src/socket/services/socket-room.service.ts
+++ b/apps/backend/src/socket/services/socket-room.service.ts
@@ -63,9 +63,9 @@ export class SocketRoomService {
         });
       }
       const roomIsOpen = room.availableToJoin;
-      const userIsRoomMember =
-        room.hostRef?.toString() === user._id.toString() ||
-        room.playerRefs.map((ref) => ref.toString()).includes(user._id.toString());
+      const userIsRoomMember = room.playerRefs
+        .map((ref) => ref.toString())
+        .includes(user._id.toString());
       if (!roomIsOpen || !userIsRoomMember) {
         this.logger.error(
           `${user._id} could not join room ${roomId}: ${
@@ -85,16 +85,34 @@ export class SocketRoomService {
       } else {
         socket.join(roomId);
       }
-      const roomMetadata = await this.handleGetRoomMetadata({ roomId, socketServer, user }, true);
+      const { success, data: roomMetadata } = await this.handleGetRoomMetadata(
+        { roomId, socketServer, user },
+        { room: true, userInRoom: true }
+      );
+
+      if (!success) {
+        const errorData = new SocketEventError(
+          SocketEventErrorCode.UNKNOWN,
+          'Cannot get room metadata',
+          {
+            roomId,
+          }
+        );
+        return new SocketEventResponse({
+          success: false,
+          error: errorData,
+        });
+      }
+
       socket.to(roomId).emit(SocketEvent.USER_JOINED_ROOM, {
         username: user.username,
-        metadata: roomMetadata,
+        metadata: roomMetadata as IRoomMetadata,
       });
       return new SocketEventResponse({
         success: true,
         data: {
           room,
-          metadata: roomMetadata.data ? (roomMetadata.data as IRoomMetadata) : {},
+          metadata: roomMetadata as IRoomMetadata,
         },
       });
     } catch (error) {
@@ -114,14 +132,25 @@ export class SocketRoomService {
    * @description gets metadata for specified room
    */
   async handleGetRoomMetadata(
-    { roomId, socketServer }: ISocketServiceMethodParamsWithRoomId,
-    byPassRoomValidation = false
+    { roomId, socketServer, user }: ISocketServiceMethodParamsWithRoomId,
+    byPassValidations = {
+      room: false,
+      userInRoom: false,
+    }
   ) {
     try {
-      if (!byPassRoomValidation) {
+      if (!byPassValidations.room || !byPassValidations.userInRoom) {
         const room = await this.roomsService.findRoomByRef(roomId);
         if (!room) {
           throw new Error(`Room ${roomId} not found. Check the room id and try again!`);
+        }
+        if (!byPassValidations.userInRoom) {
+          const userIsRoomMember = room.playerRefs
+            .map((ref) => ref.toString())
+            .includes(user._id.toString());
+          if (!userIsRoomMember) {
+            throw new Error(`User ${user._id} is not a member of room ${room._id}`);
+          }
         }
       }
 

--- a/apps/backend/src/socket/socket.gateway.ts
+++ b/apps/backend/src/socket/socket.gateway.ts
@@ -63,6 +63,19 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   }
 
   @UseGuards(JwtWsAuthGuard)
+  @SubscribeMessage(SocketEvent.GET_ROOM_METADATA)
+  getRoomMetadata(
+    @CurrentUserFromRequest() user: UserWithoutPassword,
+    @MessageBody('roomId') roomId: string
+  ) {
+    return this.socketRoomService.handleGetRoomMetadata({
+      roomId,
+      socketServer: this.server,
+      user,
+    });
+  }
+
+  @UseGuards(JwtWsAuthGuard)
   @SubscribeMessage(SocketEvent.CLOSE_ROOM)
   closeRoom(
     @CurrentUserFromRequest() user: UserWithoutPassword,

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -32,6 +32,7 @@
     "@inno/utils": "*",
     "@react-native-async-storage/async-storage": "1.18.2",
     "expo": "^49.0.0",
+    "expo-clipboard": "~4.3.1",
     "expo-constants": "~14.4.2",
     "expo-linking": "~5.0.2",
     "expo-router": "^2.0.0",

--- a/apps/native/src/app-core/components/clipboard/CopyableText.tsx
+++ b/apps/native/src/app-core/components/clipboard/CopyableText.tsx
@@ -1,0 +1,49 @@
+import { Button, ButtonText, useToast } from '@gluestack-ui/themed';
+import * as Clipboard from 'expo-clipboard';
+
+import { CustomToast } from '../toasts/CustomToast';
+
+export const CopyableText = ({ text }: { text: string }) => {
+  const toast = useToast();
+
+  const copyToClipboard = async () => {
+    try {
+      await Clipboard.setStringAsync(text);
+      toast.show({
+        placement: 'top',
+        render: ({ id }) => (
+          <CustomToast
+            id={id}
+            title="Copied Text"
+            description={`${text} was successfully copied to clipboard.`}
+          />
+        ),
+      });
+    } catch (_e) {
+      toast.show({
+        placement: 'top',
+        render: ({ id }) => (
+          <CustomToast
+            action="error"
+            id={id}
+            title="Copied Text Error"
+            description="Unable to copy text to clipboard"
+          />
+        ),
+      });
+    }
+  };
+
+  return (
+    <Button
+      size="md"
+      variant="link"
+      action="secondary"
+      isDisabled={false}
+      isFocusVisible={false}
+      onPress={copyToClipboard}
+    >
+      <ButtonText>{text}</ButtonText>
+    </Button>
+  );
+};

--- a/apps/native/src/app-core/components/toasts/CustomToast.tsx
+++ b/apps/native/src/app-core/components/toasts/CustomToast.tsx
@@ -1,15 +1,16 @@
 import { Toast, ToastDescription, ToastTitle, VStack } from '@gluestack-ui/themed';
 
 export interface ICustomToastProps {
+  action?: 'error' | 'warning' | 'success' | 'info' | 'attention' | undefined;
   description: string;
   id: string;
   title: string;
 }
 
-export const CustomToast = ({ description, id, title }: ICustomToastProps) => {
+export const CustomToast = ({ action, description, id, title }: ICustomToastProps) => {
   const toastId = 'toast-' + id;
   return (
-    <Toast nativeID={toastId} action="attention" variant="solid">
+    <Toast nativeID={toastId} action={action ?? 'attention'} variant="solid">
       <VStack space="xs">
         <ToastTitle>{title}</ToastTitle>
         <ToastDescription>{description}</ToastDescription>

--- a/apps/native/src/rooms/components/JoinRoomCTA.tsx
+++ b/apps/native/src/rooms/components/JoinRoomCTA.tsx
@@ -1,93 +1,39 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Box, Button, ButtonText } from '@gluestack-ui/themed';
 import { Text } from '@gluestack-ui/themed';
 import { router } from 'expo-router';
-import { Socket } from 'socket.io-client';
-
-import { SocketEvent, SocketEventError, SocketEventResponse } from '@inno/constants';
-import { useAddPlayerToRoomMutation } from '@inno/gql';
-import { getCatchErrorMessage } from '@inno/utils';
 
 import { InteractiveModal } from '../../app-core/components/modal/InteractiveModal';
 import { Routes } from '../../app-core/constants/navigation';
 import { JoinRoomForm } from '../forms/JoinRoomForm';
+import { useJoinRoom } from '../hooks/useJoinRoom';
 import { JoinRoomFormData } from '../room.types';
 
-export interface IJoinRoomCTAProps {
-  socket?: Socket;
-}
-
-export const JoinRoomCTA = ({ socket }: IJoinRoomCTAProps) => {
-  const [addPlayerToRoomMutation, { loading: addPlayerToRoomMutationLoading }] =
-    useAddPlayerToRoomMutation({
-      fetchPolicy: 'no-cache',
-    });
-
+export const JoinRoomCTA = () => {
   const [showModal, setShowModal] = useState(false);
-  const [errorMsg, setErrorMsg] = useState<string>();
-  const [joinInProgress, setJoinInProgress] = useState(false);
 
   const handleClose = useCallback(() => {
     setShowModal(false);
   }, []);
 
-  const handleJoinRoom = async (roomId: string) => {
-    if (!socket || !socket?.connected) {
-      setErrorMsg('Unexpected error occurred. Please refresh and try again!');
-      setJoinInProgress(false);
-      return;
-    }
-    await socket?.emit(
-      SocketEvent.JOIN_ROOM,
-      { roomId: roomId },
-      (response: SocketEventResponse) => {
-        if (!response.success) {
-          setErrorMsg(response.error?.message || 'Error joining room');
-          setJoinInProgress(false);
-          return;
-        }
-        setJoinInProgress(false);
-        setShowModal(false);
-        router.push({
-          pathname: Routes.ROOM,
-          params: { roomId },
-        });
-      }
-    );
+  const handleSuccessfulJoinRoom = (roomId: string) => {
+    setShowModal(false);
+    router.push({
+      pathname: Routes.ROOM,
+      params: { roomId },
+    });
   };
+
+  const {
+    handleJoinRoom,
+    errorMsg,
+    loading: joinLoading,
+  } = useJoinRoom({ successCallback: handleSuccessfulJoinRoom });
 
   const handleSubmit = async (data: JoinRoomFormData) => {
-    setJoinInProgress(true);
-
-    addPlayerToRoomMutation({
-      variables: {
-        roomId: data.roomId,
-      },
-      onCompleted(data) {
-        if (!data?.addPlayerToRoom?._id) {
-          setErrorMsg('An error occurred. Please try again!');
-          setJoinInProgress(false);
-          return;
-        }
-        handleJoinRoom(data?.addPlayerToRoom._id);
-      },
-      onError(error) {
-        setErrorMsg(getCatchErrorMessage(error, 'An error occurred. Please try again!'));
-        setJoinInProgress(false);
-      },
-    });
+    handleJoinRoom(data.roomId);
   };
-
-  useEffect(() => {
-    socket?.on(SocketEvent.JOIN_ROOM_ERROR, (error: SocketEventError) => {
-      setErrorMsg(error.message);
-    });
-
-    return () => {
-      socket?.removeListener(SocketEvent.JOIN_ROOM_ERROR);
-    };
-  }, [socket]);
 
   return (
     <Box>
@@ -98,11 +44,7 @@ export const JoinRoomCTA = ({ socket }: IJoinRoomCTAProps) => {
         <>
           <Text>Already know the id for the room you want to join?</Text>
           <Text>Enter it here to get playing faster!</Text>
-          <JoinRoomForm
-            error={errorMsg}
-            loading={joinInProgress || addPlayerToRoomMutationLoading}
-            onSubmit={handleSubmit}
-          />
+          <JoinRoomForm error={errorMsg} loading={joinLoading} onSubmit={handleSubmit} />
         </>
       </InteractiveModal>
     </Box>

--- a/apps/native/src/rooms/forms/CreateRoomForm.tsx
+++ b/apps/native/src/rooms/forms/CreateRoomForm.tsx
@@ -54,6 +54,8 @@ export const CreateRoomForm = ({ error: customError, loading, onSubmit }: ICreat
         <FormError errorMsg={errors.roomName?.message as string} />
       </Box>
 
+      <FormError errorMsg={customError} />
+
       <HStack justifyContent="flex-end">
         <Button
           onPress={handleSubmit(onSubmit)}
@@ -66,7 +68,6 @@ export const CreateRoomForm = ({ error: customError, loading, onSubmit }: ICreat
           <ButtonText>Create Room</ButtonText>
         </Button>
       </HStack>
-      <FormError errorMsg={customError} />
     </Box>
   );
 };

--- a/apps/native/src/rooms/forms/JoinRoomForm.tsx
+++ b/apps/native/src/rooms/forms/JoinRoomForm.tsx
@@ -60,6 +60,8 @@ export const JoinRoomForm = ({ error: customError, loading, onSubmit }: IJoinRoo
         <FormError errorMsg={errors.roomId?.message as string} />
       </Box>
 
+      <FormError errorMsg={customError} />
+
       <HStack justifyContent="flex-end">
         <Button
           onPress={handleSubmit(onSubmit)}
@@ -72,7 +74,6 @@ export const JoinRoomForm = ({ error: customError, loading, onSubmit }: IJoinRoo
           <ButtonText>Join</ButtonText>
         </Button>
       </HStack>
-      <FormError errorMsg={customError} />
     </Box>
   );
 };

--- a/apps/native/src/rooms/forms/validation/create-room-schema.ts
+++ b/apps/native/src/rooms/forms/validation/create-room-schema.ts
@@ -8,7 +8,7 @@ export const createRoomFormSchema: ZodType<CreateRoomFormData> = z.object({
     .min(5, 'Room name must be at least 5 characters long')
     .max(100, 'Room name may not be more than 100 characters long')
     .refine(
-      (value) => /^[\w_\-]+$/.test(value),
-      "Room name may only contain letters, numbers, '_', and/or '-'"
+      (value) => /^[a-zA-Z0-9 ]*$/gm.test(value),
+      "Room name may only contain letters, numbers, and spaces (' ')"
     ),
 });

--- a/apps/native/src/rooms/forms/validation/join-room-schema.ts
+++ b/apps/native/src/rooms/forms/validation/join-room-schema.ts
@@ -3,5 +3,10 @@ import { ZodType, z } from 'zod';
 import { JoinRoomFormData } from '../../room.types';
 
 export const joinRoomFormSchema: ZodType<JoinRoomFormData> = z.object({
-  roomId: z.string(),
+  roomId: z
+    .string()
+    .refine(
+      (value) => /^[a-zA-Z0-9]*$/gm.test(value),
+      'Room ID may only contain letters and numbers. Check the ID and try again.'
+    ),
 });

--- a/apps/native/src/rooms/hooks/useJoinRoom.ts
+++ b/apps/native/src/rooms/hooks/useJoinRoom.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+
+import { SocketEvent, SocketEventError, SocketEventResponse } from '@inno/constants';
+import { useAddPlayerToRoomMutation } from '@inno/gql';
+
+import { useSocketContext } from '../../websockets/SocketProvider';
+
+export const useJoinRoom = ({
+  successCallback,
+}: {
+  successCallback?: (roomId: string) => void;
+}) => {
+  const { socket } = useSocketContext();
+  const [addPlayerToRoomMutation, { loading: addPlayerToRoomMutationLoading }] =
+    useAddPlayerToRoomMutation({
+      fetchPolicy: 'no-cache',
+    });
+
+  const [errorMsg, setErrorMsg] = useState<string>();
+  const [joinInProgress, setJoinInProgress] = useState(false);
+  const [joinSuccessful, setJoinSuccessful] = useState(false);
+
+  const handleJoinRoomEvent = async (roomId: string) => {
+    if (!socket || !socket?.connected) {
+      setErrorMsg('Unexpected error occurred. Please refresh and try again!');
+      setJoinInProgress(false);
+      return;
+    }
+    await socket?.emit(
+      SocketEvent.JOIN_ROOM,
+      { roomId: roomId },
+      (response: SocketEventResponse) => {
+        if (!response.success) {
+          setErrorMsg(response.error?.message || 'Error joining room');
+          setJoinInProgress(false);
+          return;
+        }
+        setJoinInProgress(false);
+        setJoinSuccessful(true);
+        if (successCallback) {
+          successCallback(roomId);
+        }
+      }
+    );
+  };
+
+  const handleJoinRoom = async (roomId: string) => {
+    setJoinInProgress(true);
+
+    addPlayerToRoomMutation({
+      variables: {
+        roomId,
+      },
+      onCompleted(data) {
+        if (!data?.addPlayerToRoom?._id) {
+          setErrorMsg('An error occurred. Please try again.');
+          setJoinInProgress(false);
+          return;
+        }
+        handleJoinRoomEvent(data?.addPlayerToRoom._id);
+      },
+      onError() {
+        setErrorMsg('An error occurred. Check the Room ID and try again.');
+        setJoinInProgress(false);
+      },
+    });
+  };
+
+  useEffect(() => {
+    socket?.on(SocketEvent.JOIN_ROOM_ERROR, (error: SocketEventError) => {
+      setErrorMsg(error.message);
+    });
+
+    return () => {
+      socket?.removeListener(SocketEvent.JOIN_ROOM_ERROR);
+    };
+  }, [socket]);
+
+  return {
+    errorMsg,
+    loading: joinInProgress || addPlayerToRoomMutationLoading,
+    joinSuccessful,
+    handleJoinRoom,
+  };
+};

--- a/apps/native/src/rooms/screens/RoomScreen.tsx
+++ b/apps/native/src/rooms/screens/RoomScreen.tsx
@@ -209,11 +209,7 @@ export const RoomScreen = ({ error, loading, refetchRoomData, roomData }: IRoomS
         onConfirm={handleConfirmLeaveRoom}
         confirmText="Confirm Leave Room"
       >
-        <Text>If you are the host, this will end the game for everyone.</Text>
-        <Text>
-          If you are a player, this will remove you from the game and everyone else will continue to
-          play.
-        </Text>
+        <Text>Leaving will end the game for everyone.</Text>
         {leaveRoomError ? <FormError errorMsg={leaveRoomError} /> : null}
       </InteractiveModal>
     </>

--- a/apps/native/src/rooms/screens/RoomScreen.tsx
+++ b/apps/native/src/rooms/screens/RoomScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ApolloError } from '@apollo/client';
 import {
@@ -18,6 +18,7 @@ import { IRoomMetadata, SocketEvent, SocketEventError, SocketEventResponse } fro
 import { RoomDataFragment, useCloseRoomMutation } from '@inno/gql';
 import { getCatchErrorMessage } from '@inno/utils';
 
+import { CopyableText } from '../../app-core/components/clipboard/CopyableText';
 import { InteractiveModal } from '../../app-core/components/modal/InteractiveModal';
 import { CustomToast } from '../../app-core/components/toasts/CustomToast';
 import { Routes } from '../../app-core/constants/navigation';
@@ -44,6 +45,26 @@ export const RoomScreen = ({ error, loading, refetchRoomData, roomData }: IRoomS
   const [showModal, setShowModal] = useState(false);
   const [leaveRoomError, setLeaveRoomError] = useState('');
   const [usersInRoom, setUsersInRoom] = useState(0);
+
+  const userIsHost = useMemo(
+    () => !!(user?._id && roomData?.hostRef && user._id === roomData.hostRef),
+    [user?._id, roomData?.hostRef]
+  );
+
+  // get current room metadata on when roomId exists and/or changes
+  useEffect(() => {
+    if (roomData?._id) {
+      socket?.emit(
+        SocketEvent.GET_ROOM_METADATA,
+        { roomId: roomData?._id },
+        ({ success, data }: SocketEventResponse & { data: IRoomMetadata }) => {
+          if (success && data?.playersInRoom) {
+            setUsersInRoom(data.playersInRoom);
+          }
+        }
+      );
+    }
+  }, [roomData?._id]);
 
   useEffect(() => {
     socket?.on(
@@ -168,8 +189,17 @@ export const RoomScreen = ({ error, loading, refetchRoomData, roomData }: IRoomS
         </HStack>
         <Box alignItems="center">
           <Text>Welcome to the {roomData.name} room!</Text>
-          <Text>There are currently {usersInRoom} players in the room.</Text>
-          <Text>There are {roomData.playerRefs.length + 1} players currently allowed in room.</Text>
+          <Text>
+            The room is currently{roomData.availableToJoin ? ' ' : ' not '}available to join.
+          </Text>
+          <Text>There are {roomData.playerRefs.length} members of the room.</Text>
+          <Text>There are currently {usersInRoom} players connected to the room.</Text>
+          {userIsHost && !!roomData?._id && (
+            <HStack alignItems="center">
+              <Text>Invite more players by sharing this room id (click to copy): </Text>
+              <CopyableText text={roomData._id} />
+            </HStack>
+          )}
         </Box>
       </VStack>
       <InteractiveModal

--- a/apps/native/src/screens/HomeScreen.tsx
+++ b/apps/native/src/screens/HomeScreen.tsx
@@ -5,10 +5,8 @@ import { StatusBar } from 'expo-status-bar';
 import { Routes } from '../app-core/constants/navigation';
 import { CreateRoomCTA } from '../rooms/components/CreateRoomCTA';
 import { JoinRoomCTA } from '../rooms/components/JoinRoomCTA';
-import { useSocketContext } from '../websockets/SocketProvider';
 
 export const HomeScreen = () => {
-  const { socket } = useSocketContext();
   return (
     <>
       <StatusBar style="auto" />
@@ -24,8 +22,8 @@ export const HomeScreen = () => {
             <ButtonText>Authenticate</ButtonText>
           </Button>
         </Link>
-        <CreateRoomCTA socket={socket} />
-        <JoinRoomCTA socket={socket} />
+        <CreateRoomCTA />
+        <JoinRoomCTA />
         <Link href={Routes.EXAMPLES} asChild>
           <Button
             size="md"

--- a/packages/constants/src/rooms.ts
+++ b/packages/constants/src/rooms.ts
@@ -3,3 +3,5 @@ export interface IRoomMetadata {
   playersInRoom: number;
   roomId: string;
 }
+
+export const MAX_USERS_PER_ROOM = 2;

--- a/packages/constants/src/sockets.ts
+++ b/packages/constants/src/sockets.ts
@@ -31,6 +31,7 @@ export enum SocketEvent {
 
   // client-Emitted Events
   CLOSE_ROOM = 'closeRoom',
+  GET_ROOM_METADATA = 'getRoomMetadata',
   JOIN_ROOM = 'joinRoom',
 
   // event emitted to rooms

--- a/yarn.lock
+++ b/yarn.lock
@@ -9075,6 +9075,11 @@ expo-asset@~8.10.1:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
+expo-clipboard@~4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-4.3.1.tgz#ce6ed35ae31c7fc1aeadb005b8eb9b39a8bb9b40"
+  integrity sha512-WIsjvAsr2+/NZRa84mKxjui1EdPpdKbQIC2LN/KMBNuT7g4GQYL3oo9WO9G/C7doKQ7f7pnfdvO3N6fUnoRoJw==
+
 expo-constants@~14.4.2:
   version "14.4.2"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-14.4.2.tgz#cac5e8b524069545739b8d8595ce96cc5be6578c"


### PR DESCRIPTION
## Summary

- Close room if too many player or on final player joining
- Enable getting room metadata from direct web socket event
- Update create room name schema validation
- Abstract join room logic to share across create room and join room CTAs
- Add `expo-clipboard` dep and create shared `CopyableText` component
- Use `CopyableText` component to enable host to copy & share room id with other players

## Demo


https://github.com/sbarli/innovation/assets/12473529/3cb57eb3-7c57-4004-8558-a950fbeff432


