### PR TITLE
Feat: UI: Card Front with Details Popover

### DIFF
--- a/apps/native/src/app-core/constants/colors.ts
+++ b/apps/native/src/app-core/constants/colors.ts
@@ -15,6 +15,7 @@ const BROWN_PALLETE = {
 
 export const BORDER_COLOR_LIGHT = '$trueGray50';
 export const TEXT_COLOR_LIGHT = '$trueGray50';
+export const TEXT_COLOR_DARK = '$trueGray900';
 export const CARD_BACK_BORDER_COLOR_LIGHT = BROWN_PALLETE.brown100;
 export const CARD_BACK_COLOR_LIGHT = BROWN_PALLETE.brown200;
 export const CARD_BACK_COLOR_DARK = BROWN_PALLETE.brown900;
@@ -33,6 +34,14 @@ export const secondaryCardColorMap = {
   [Color.PURPLE]: '$violet900',
   [Color.RED]: '$red900',
   [Color.YELLOW]: '$yellow800',
+};
+
+export const tertiaryCardColorMap = {
+  [Color.BLUE]: '$blue50',
+  [Color.GREEN]: '$green100',
+  [Color.PURPLE]: '$purple50',
+  [Color.RED]: '$red200',
+  [Color.YELLOW]: '$yellow50',
 };
 
 export const resourceColorMap = {

--- a/apps/native/src/cards/components/AllCards.tsx
+++ b/apps/native/src/cards/components/AllCards.tsx
@@ -2,8 +2,8 @@ import { Box, HStack, Text } from '@gluestack-ui/themed';
 
 import { useGetAllCardsQuery } from '@inno/gql';
 
+import { CardFrontWithDetails } from './CardFrontWithDetails';
 import { CardBack } from './back/CardBack';
-import { CardFront } from './front/CardFront';
 
 export const AllCards = () => {
   const { data, loading } = useGetAllCardsQuery();
@@ -16,18 +16,23 @@ export const AllCards = () => {
     );
   }
   return (
-    <Box w="$full" paddingHorizontal="$10">
-      <HStack w="$full" space="md">
-        {allCards?.slice(0, 3).map((c) => <CardFront key={c.cardId} card={c} />)}
+    <Box w="$full" paddingHorizontal="$10" gap="$2.5">
+      <HStack w="$full" space="md" gap="$2.5">
+        {allCards?.slice(0, 3).map((c) => <CardFrontWithDetails key={c.cardId} card={c} />)}
       </HStack>
-      <HStack w="$full" space="md">
+      <HStack w="$full" space="md" gap="$2.5">
+        {allCards
+          ?.slice(allCards.length - 8, allCards.length - 4)
+          .map((c) => <CardFrontWithDetails key={c.cardId} card={c} />)}
+      </HStack>
+      <HStack w="$full" space="md" gap="$2.5">
         <CardBack age={1} />
         <CardBack age={2} />
         <CardBack age={3} />
         <CardBack age={4} />
         <CardBack age={5} />
       </HStack>
-      <HStack w="$full" space="md">
+      <HStack w="$full" space="md" gap="$2.5">
         <CardBack age={6} />
         <CardBack age={7} />
         <CardBack age={8} />

--- a/apps/native/src/cards/components/CardFrontWithDetails.tsx
+++ b/apps/native/src/cards/components/CardFrontWithDetails.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+import {
+  Popover,
+  PopoverBackdrop,
+  PopoverContent,
+  PopoverArrow,
+  Heading,
+  PopoverCloseButton,
+  Icon,
+  CloseIcon,
+  PopoverHeader,
+  PopoverBody,
+  Pressable,
+} from '@gluestack-ui/themed';
+
+import { Card as CardType } from '@inno/gql';
+
+import { CardDetails } from './front/CardDetails';
+import { CardFront } from './front/CardFront';
+
+export interface ICardFrontWithDetailsProps {
+  card: CardType;
+}
+
+export const CardFrontWithDetails = ({ card }: ICardFrontWithDetailsProps) => {
+  const [isCardDetailOpen, setIsCardDetailOpen] = useState(false);
+  const handleCloseCardDetails = () => {
+    setIsCardDetailOpen(false);
+  };
+  const handleOpenCardDetails = () => {
+    setIsCardDetailOpen(true);
+  };
+  return (
+    <>
+      <Popover
+        isOpen={isCardDetailOpen}
+        onClose={handleCloseCardDetails}
+        onOpen={handleOpenCardDetails}
+        placement="bottom"
+        size="md"
+        trigger={(triggerProps) => {
+          return (
+            <Pressable {...triggerProps}>
+              <CardFront card={card} />
+            </Pressable>
+          );
+        }}
+      >
+        <PopoverBackdrop />
+        <PopoverContent>
+          <PopoverArrow />
+          <PopoverHeader>
+            <Heading size="sm">{card.name}</Heading>
+            <PopoverCloseButton>
+              <Icon as={CloseIcon} />
+            </PopoverCloseButton>
+          </PopoverHeader>
+          <PopoverBody>
+            <CardDetails card={card} />
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+};

--- a/apps/native/src/cards/components/front/CardDetails.tsx
+++ b/apps/native/src/cards/components/front/CardDetails.tsx
@@ -1,0 +1,55 @@
+import { Box, HStack, VStack } from '@gluestack-ui/themed';
+
+import { Color, Resource } from '@inno/constants';
+import { Card as CardType } from '@inno/gql';
+
+import { primaryCardColorMap } from '../../../app-core/constants/colors';
+
+import { CardAge } from './CardAge';
+import { CardName } from './CardName';
+import { DogmaEffect } from './DogmaEffect';
+import { ResourceSpace } from './ResourceSpace';
+
+export interface ICardDetailsProps {
+  card: CardType;
+}
+
+export const CardDetails = ({ card }: ICardDetailsProps) => {
+  const resourceSpace1 = card.resourceSpaces.resourceSpace1 as Resource;
+  const resourceSpace2 = card.resourceSpaces.resourceSpace2 as Resource;
+  const resourceSpace3 = card.resourceSpaces.resourceSpace3 as Resource;
+  const resourceSpace4 = card.resourceSpaces.resourceSpace4 as Resource;
+  const colorEnum = card.color as Color;
+  return (
+    <Box
+      bg={primaryCardColorMap[card.color as Color]}
+      padding="$3.5"
+      borderRadius="$md"
+      w="$full"
+      minHeight="$48"
+      justifyContent="space-between"
+    >
+      <HStack justifyContent="space-between" w="$full">
+        <ResourceSpace cardColor={colorEnum} resource={resourceSpace1} />
+        <CardName color={colorEnum} name={card.name} />
+        <CardAge age={card.age} color={colorEnum} />
+      </HStack>
+      <VStack gap="$5" paddingVertical="$5">
+        {/* NOTE: using map instead of Flatlist due to small amount of data + removing Virtualized list inside scrollview error */}
+        {card.dogmaEffects.map((effect, index) => (
+          <DogmaEffect
+            key={`${card.name}_dogmaEffect_${index}`}
+            color={colorEnum}
+            effectDescription={effect.description}
+            isDemand={effect.isDemand}
+          />
+        ))}
+      </VStack>
+      <HStack justifyContent="space-between" w="$full">
+        <ResourceSpace cardColor={colorEnum} resource={resourceSpace2} />
+        <ResourceSpace cardColor={colorEnum} resource={resourceSpace3} />
+        <ResourceSpace cardColor={colorEnum} resource={resourceSpace4} />
+      </HStack>
+    </Box>
+  );
+};

--- a/apps/native/src/cards/components/front/DogmaEffect.tsx
+++ b/apps/native/src/cards/components/front/DogmaEffect.tsx
@@ -1,0 +1,32 @@
+import { Box } from '@gluestack-ui/themed';
+import { Text } from '@gluestack-ui/themed';
+
+import { Color } from '@inno/constants';
+
+import {
+  TEXT_COLOR_DARK,
+  TEXT_COLOR_LIGHT,
+  secondaryCardColorMap,
+  tertiaryCardColorMap,
+} from '../../../app-core/constants/colors';
+
+export interface IDogmaEffectProps {
+  color: Color;
+  effectDescription: string;
+  isDemand: boolean;
+}
+
+export const DogmaEffect = ({ color, effectDescription, isDemand = false }: IDogmaEffectProps) => {
+  return (
+    <Box
+      bg={isDemand ? secondaryCardColorMap[color] : tertiaryCardColorMap[color]}
+      paddingVertical="$1"
+      paddingHorizontal="$3"
+      marginHorizontal="$2"
+    >
+      <Text color={isDemand ? TEXT_COLOR_LIGHT : TEXT_COLOR_DARK} size="sm">
+        {effectDescription}
+      </Text>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary

- Created new components to support displaying detailed card view in a Gluestack [Popover](https://v1.gluestack.io/ui/docs/components/overlay/popover)
    - Includes displaying dogma descriptions for each dogma effect, and UI for demand type effects

## Demo


https://github.com/user-attachments/assets/aef52e1b-17c7-43fe-a357-7f2c2ab3903e



## Testing

N/A

### Test Coverage

N/A