### PR TITLE
only run CI when selected file paths have changed

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'packages/utils/**'
   pull_request:
     types: [opened, synchronize]
+    paths: 
+      - 'apps/backend/**'
+      - 'packages/constants/**'
+      - 'packages/utils/**'
  
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Right now we only have unit tests for backend so we only need to run the backend-ci file on backend changes
- See [this SO post](https://stackoverflow.com/a/70569968) for details on using `paths` for `pull-requests` flows
