### PR TITLE
E2E/cleanup start game

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # lint the repo
-yarn turbo run lint:fix --filter="[HEAD^1]"
+yarn turbo run lint:fix
 
 # test the repo
-yarn turbo run test --filter="[HEAD^1]"
+yarn turbo run test

--- a/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
+++ b/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
@@ -34,10 +34,5 @@ export const MOCK_PLAYER_2_DETAILS: PlayerGameDetails = {
 };
 
 export const MOCK_NEW_GAME_RESPONSE: CreateNewGameResponse = {
-  game: {
-    ...MOCK_GAME,
-    playerRefs: MOCK_NEW_GAME_INPUT.playerRefs,
-    currentPlayerRef: MOCK_USER_ID,
-  },
-  playerGameDetails: [MOCK_PLAYER_1_DETAILS, MOCK_PLAYER_2_DETAILS],
+  gameId: 'MOCK_GAME_ID',
 };

--- a/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
+++ b/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
@@ -34,5 +34,5 @@ export const MOCK_PLAYER_2_DETAILS: PlayerGameDetails = {
 };
 
 export const MOCK_NEW_GAME_RESPONSE: CreateNewGameResponse = {
-  gameId: 'MOCK_GAME_ID',
+  gameId: MOCK_GAME._id,
 };

--- a/apps/backend/src/gameplay/dto/create-new-game.output.dto.ts
+++ b/apps/backend/src/gameplay/dto/create-new-game.output.dto.ts
@@ -1,12 +1,7 @@
-import { Field, ObjectType } from '@nestjs/graphql';
-import { Game } from 'src/games/schemas/game.schema';
-import { PlayerGameDetails } from 'src/player-game-details/schemas/player-game-details.schema';
+import { Field, ID, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class CreateNewGameResponse {
-  @Field(() => Game)
-  game!: Game;
-
-  @Field(() => [PlayerGameDetails])
-  playerGameDetails!: PlayerGameDetails[];
+  @Field(() => ID)
+  gameId!: string;
 }

--- a/apps/backend/src/gameplay/services/new-game.service.ts
+++ b/apps/backend/src/gameplay/services/new-game.service.ts
@@ -147,14 +147,14 @@ export class NewGameService {
         // TODO: add once we have spec achiev added to schema
         // specialAchievements: [],
       }));
-      const allPlayerGameDetails = await Promise.all(
+      // TODO: do we need to have any other checks that this was successful?
+      await Promise.all(
         playerGameDetailsData.map((pgd) => this.playerGameDetailsService.create(pgd))
       );
 
       // return newly created game and game details (per player)
       return {
-        game: newGameFromDb,
-        playerGameDetails: allPlayerGameDetails,
+        gameId: newGameFromDb._id,
       };
     } catch (error) {
       throw new Error(

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -124,8 +124,7 @@ input CreateNewGameInput {
 }
 
 type CreateNewGameResponse {
-  game: Game!
-  playerGameDetails: [PlayerGameDetails!]!
+  gameId: ID!
 }
 
 input CreatePlayerGameDetailsInput {

--- a/apps/native/src/rooms/hooks/useStartNewGame.ts
+++ b/apps/native/src/rooms/hooks/useStartNewGame.ts
@@ -35,7 +35,7 @@ export const useStartNewGame = ({
     }
   };
 
-  const handleStartGameEvent = async ({ game }: NewGameMutation['newGame']) => {
+  const handleStartGameEvent = async ({ gameId }: NewGameMutation['newGame']) => {
     if (!socket || !socket?.connected) {
       setErrorMsg('Unexpected error occurred. Please refresh and try again!');
       setStartInProgress(false);
@@ -43,7 +43,7 @@ export const useStartNewGame = ({
     }
     await socket?.emit(
       SocketEvent.START_GAME,
-      { gameId: game._id, roomId: roomId as string },
+      { gameId: gameId as string, roomId: roomId as string },
       (response: SocketEventResponse) => {
         if (!response.success) {
           setErrorMsg(response.error?.message || 'Error starting game');
@@ -52,9 +52,9 @@ export const useStartNewGame = ({
         }
         setStartInProgress(false);
         setStartSuccessful(true);
-        handleRedirectToGameScreen(game._id);
+        handleRedirectToGameScreen(gameId);
         if (successCallback) {
-          successCallback(game._id);
+          successCallback(gameId);
         }
       }
     );
@@ -68,7 +68,7 @@ export const useStartNewGame = ({
         newGameDto: newRoomData,
       },
       onCompleted(data) {
-        if (!data?.newGame?.game || !data?.newGame?.playerGameDetails) {
+        if (!data?.newGame?.gameId) {
           setErrorMsg('An error occurred. Please try again.');
           setStartInProgress(false);
           return;

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -152,8 +152,7 @@ export type CreateNewGameInput = {
 
 export type CreateNewGameResponse = {
   __typename?: 'CreateNewGameResponse';
-  game: Game;
-  playerGameDetails: Array<PlayerGameDetails>;
+  gameId: Scalars['ID']['output'];
 };
 
 export type CreatePlayerGameDetailsInput = {
@@ -497,7 +496,7 @@ export type NewGameMutationVariables = Exact<{
 }>;
 
 
-export type NewGameMutation = { __typename?: 'Mutation', newGame: { __typename?: 'CreateNewGameResponse', game: { __typename?: 'Game', _id: string, currentActionNumber: number, currentPlayerRef: string, playerRefs: Array<string>, winnerRef?: string | null, deck: { __typename?: 'Deck', ONE: Array<string>, TWO: Array<string>, THREE: Array<string>, FOUR: Array<string>, FIVE: Array<string>, SIX: Array<string>, SEVEN: Array<string>, EIGHT: Array<string>, NINE: Array<string>, TEN: Array<string> }, achievements: { __typename?: 'Achievements', ONE: string, TWO: string, THREE: string, FOUR: string, FIVE: string, SIX: string, SEVEN: string, EIGHT: string, NINE: string } }, playerGameDetails: Array<{ __typename?: 'PlayerGameDetails', _id: string, playerRef: string, username?: string | null, age: number, score: number, achievements: Array<string>, hand: Array<string>, scoreCardRefs: Array<string>, resourceTotals: { __typename?: 'ResourceTotals', castles: number, crowns: number, leaves: number, lightbulbs: number, factories: number, timepieces: number }, board: { __typename?: 'Board', blue: { __typename?: 'BoardPile', cardRefs: Array<string>, splayed?: SplayOption | null }, green: { __typename?: 'BoardPile', cardRefs: Array<string>, splayed?: SplayOption | null }, purple: { __typename?: 'BoardPile', cardRefs: Array<string>, splayed?: SplayOption | null }, red: { __typename?: 'BoardPile', cardRefs: Array<string>, splayed?: SplayOption | null }, yellow: { __typename?: 'BoardPile', cardRefs: Array<string>, splayed?: SplayOption | null } } }> } };
+export type NewGameMutation = { __typename?: 'Mutation', newGame: { __typename?: 'CreateNewGameResponse', gameId: string } };
 
 export type AvailableAchievementsFragment = { __typename?: 'Achievements', ONE: string, TWO: string, THREE: string, FOUR: string, FIVE: string, SIX: string, SEVEN: string, EIGHT: string, NINE: string };
 
@@ -910,16 +909,10 @@ export type GetAllCardsQueryResult = Apollo.QueryResult<GetAllCardsQuery, GetAll
 export const NewGameDocument = gql`
     mutation NewGame($newGameDto: CreateNewGameInput!) {
   newGame(newGameDto: $newGameDto) {
-    game {
-      ...Game
-    }
-    playerGameDetails {
-      ...PlayerGameDetails
-    }
+    gameId
   }
 }
-    ${GameFragmentDoc}
-${PlayerGameDetailsFragmentDoc}`;
+    `;
 export type NewGameMutationFn = Apollo.MutationFunction<NewGameMutation, NewGameMutationVariables>;
 
 /**

--- a/packages/gql/src/gameplay/new-game.mutation.gql
+++ b/packages/gql/src/gameplay/new-game.mutation.gql
@@ -1,10 +1,5 @@
 mutation NewGame($newGameDto: CreateNewGameInput!) {
   newGame(newGameDto: $newGameDto) {
-    game {
-      ...Game
-    }
-    playerGameDetails {
-      ...PlayerGameDetails
-    }
+    gameId
   }
 }


### PR DESCRIPTION
## Summary

- FE only needs the newly created game `_id` to be returned when starting a new game so this PR cleans up the BE resolver & FE mutation to only include the necessary data

## Demo

## Testing

### Test Coverage