### PR TITLE
Native/Add Player Stats to Active Game

### DIFF
--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -48,6 +48,7 @@
     "expo-router": "~4.0.20",
     "expo-status-bar": "~2.0.1",
     "graphql": "^16.8.1",
+    "lucide-react-native": "^0.503.0",
     "nativewind": "^4.1.23",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/native/src/app-core/constants/game.constants.ts
+++ b/apps/native/src/app-core/constants/game.constants.ts
@@ -1,0 +1,2 @@
+// TODO: make this dynamic based on num players
+export const NUM_ACHIEVEMENTS_REQUIRED_TO_WIN = 6;

--- a/apps/native/src/app-core/types/game.types.ts
+++ b/apps/native/src/app-core/types/game.types.ts
@@ -167,6 +167,8 @@ export type PlayerMetadata = {
   score: number;
   resourceTotals: ResourceTotals;
   possibleActions: PossibleActions;
+  numAchievements: number;
+  numSpecialAchievements: number;
 };
 
 export type BoardPile = Omit<GQLBoardPile, '__typename'>;

--- a/apps/native/src/games/components/active/ActiveGame.tsx
+++ b/apps/native/src/games/components/active/ActiveGame.tsx
@@ -7,6 +7,8 @@ import { Text } from '../../../app-core/components/gluestack/text';
 import { useCurrentPlayerGameData } from '../../hooks/useCurrentPlayerGameData';
 import { useGameContext } from '../../state/GameProvider';
 
+import { StatsDrawer } from './game-stats/StatsDrawer';
+
 export const ActiveGame: FC = () => {
   const { metadata } = useGameContext();
   const { currentPlayerGameData } = useCurrentPlayerGameData();
@@ -21,6 +23,7 @@ export const ActiveGame: FC = () => {
 
   return (
     <Box>
+      <StatsDrawer />
       <Text>WELCOME TO THE ACTIVE GAME!!</Text>
     </Box>
   );

--- a/apps/native/src/games/components/active/game-stats/SinglePlayerDetails.tsx
+++ b/apps/native/src/games/components/active/game-stats/SinglePlayerDetails.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+
+import { Heading } from '../../../../app-core/components/gluestack/heading';
+import { VStack } from '../../../../app-core/components/gluestack/vstack';
+import { Player } from '../../../../app-core/types/game.types';
+
+import { Achievements } from './sections/Achievements';
+import { Age } from './sections/Age';
+import { Hand } from './sections/Hand';
+import { Score } from './sections/Score';
+
+export interface ISinglePlayerDetailsProps {
+  numCardsInHand: number;
+  playerData: Player;
+}
+
+export const SinglePlayerDetails: FC<ISinglePlayerDetailsProps> = ({
+  numCardsInHand,
+  playerData,
+}) => {
+  return (
+    <VStack>
+      <Heading size="md">{playerData.username}</Heading>
+      <Score score={playerData.metadata.score} />
+      <Achievements
+        totalNumAchievements={
+          playerData.metadata.numAchievements + playerData.metadata.numSpecialAchievements
+        }
+      />
+      <Hand numCardsInHand={numCardsInHand} />
+      <Age age={playerData.metadata.age} />
+    </VStack>
+  );
+};

--- a/apps/native/src/games/components/active/game-stats/StatsDrawer.tsx
+++ b/apps/native/src/games/components/active/game-stats/StatsDrawer.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+
+import { Button, ButtonIcon, ButtonText } from '../../../../app-core/components/gluestack/button';
+import {
+  Drawer,
+  DrawerBackdrop,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+} from '../../../../app-core/components/gluestack/drawer';
+import { Heading } from '../../../../app-core/components/gluestack/heading';
+import { MenuIcon } from '../../../../app-core/components/gluestack/icon';
+import { useGameContext } from '../../../state/GameProvider';
+
+import { SinglePlayerDetails } from './SinglePlayerDetails';
+
+export const StatsDrawer = () => {
+  const { players, hands } = useGameContext();
+  const [showDrawer, setShowDrawer] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        onPress={() => {
+          setShowDrawer(true);
+        }}
+      >
+        <ButtonIcon as={MenuIcon} className="text-typography-500" />
+        <ButtonText>Stats</ButtonText>
+      </Button>
+      <Drawer
+        isOpen={showDrawer}
+        onClose={() => {
+          setShowDrawer(false);
+        }}
+        size="sm"
+        anchor="left"
+      >
+        <DrawerBackdrop />
+        <DrawerContent>
+          <DrawerHeader>
+            <Heading size="2xl">Player Stats</Heading>
+          </DrawerHeader>
+          <DrawerBody>
+            {players && hands
+              ? // TODO: maybe make this a FlatList?
+                Object.keys(players).map((pid) => (
+                  <SinglePlayerDetails
+                    key={pid}
+                    playerData={players[pid]}
+                    numCardsInHand={hands[pid].length}
+                  />
+                ))
+              : null}
+          </DrawerBody>
+          <DrawerFooter>
+            <Button
+              onPress={() => {
+                setShowDrawer(false);
+              }}
+              className="flex-1"
+            >
+              <ButtonText>Close</ButtonText>
+            </Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};

--- a/apps/native/src/games/components/active/game-stats/sections/Achievements.tsx
+++ b/apps/native/src/games/components/active/game-stats/sections/Achievements.tsx
@@ -1,0 +1,50 @@
+import { FC, useState } from 'react';
+
+import { TrophyIcon } from 'lucide-react-native';
+
+import { HStack } from '../../../../../app-core/components/gluestack/hstack';
+import { Icon } from '../../../../../app-core/components/gluestack/icon';
+import {
+  Popover,
+  PopoverArrow,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '../../../../../app-core/components/gluestack/popover';
+import { Text } from '../../../../../app-core/components/gluestack/text';
+import { NUM_ACHIEVEMENTS_REQUIRED_TO_WIN } from '../../../../../app-core/constants/game.constants';
+
+export const Achievements: FC<{ totalNumAchievements: number }> = ({ totalNumAchievements }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      placement="top"
+      size="sm"
+      trigger={(triggerProps) => {
+        return (
+          <HStack {...triggerProps}>
+            <Icon as={TrophyIcon} />
+            <Text>{`${totalNumAchievements} / ${NUM_ACHIEVEMENTS_REQUIRED_TO_WIN}`}</Text>
+          </HStack>
+        );
+      }}
+    >
+      <PopoverBackdrop />
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverBody>
+          <Text>{`Total number of achievements (age + special)`}</Text>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/native/src/games/components/active/game-stats/sections/Age.tsx
+++ b/apps/native/src/games/components/active/game-stats/sections/Age.tsx
@@ -1,0 +1,49 @@
+import { FC, useState } from 'react';
+
+import { HandCoinsIcon } from 'lucide-react-native';
+
+import { HStack } from '../../../../../app-core/components/gluestack/hstack';
+import { Icon } from '../../../../../app-core/components/gluestack/icon';
+import {
+  Popover,
+  PopoverArrow,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '../../../../../app-core/components/gluestack/popover';
+import { Text } from '../../../../../app-core/components/gluestack/text';
+
+export const Age: FC<{ age: number }> = ({ age }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      placement="top"
+      size="sm"
+      trigger={(triggerProps) => {
+        return (
+          <HStack {...triggerProps}>
+            <Icon as={HandCoinsIcon} />
+            <Text>{age}</Text>
+          </HStack>
+        );
+      }}
+    >
+      <PopoverBackdrop />
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverBody>
+          <Text>Highest age on board</Text>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/native/src/games/components/active/game-stats/sections/Hand.tsx
+++ b/apps/native/src/games/components/active/game-stats/sections/Hand.tsx
@@ -1,0 +1,49 @@
+import { FC, useState } from 'react';
+
+import { HandIcon } from 'lucide-react-native';
+
+import { HStack } from '../../../../../app-core/components/gluestack/hstack';
+import { Icon } from '../../../../../app-core/components/gluestack/icon';
+import {
+  Popover,
+  PopoverArrow,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '../../../../../app-core/components/gluestack/popover';
+import { Text } from '../../../../../app-core/components/gluestack/text';
+
+export const Hand: FC<{ numCardsInHand: number }> = ({ numCardsInHand }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      placement="top"
+      size="sm"
+      trigger={(triggerProps) => {
+        return (
+          <HStack {...triggerProps}>
+            <Icon as={HandIcon} />
+            <Text>{numCardsInHand}</Text>
+          </HStack>
+        );
+      }}
+    >
+      <PopoverBackdrop />
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverBody>
+          <Text>Num cards in hand</Text>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/native/src/games/components/active/game-stats/sections/Score.tsx
+++ b/apps/native/src/games/components/active/game-stats/sections/Score.tsx
@@ -1,0 +1,49 @@
+import { FC, useState } from 'react';
+
+import { StarIcon } from 'lucide-react-native';
+
+import { HStack } from '../../../../../app-core/components/gluestack/hstack';
+import { Icon } from '../../../../../app-core/components/gluestack/icon';
+import {
+  Popover,
+  PopoverArrow,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '../../../../../app-core/components/gluestack/popover';
+import { Text } from '../../../../../app-core/components/gluestack/text';
+
+export const Score: FC<{ score: number }> = ({ score }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      placement="top"
+      size="sm"
+      trigger={(triggerProps) => {
+        return (
+          <HStack {...triggerProps}>
+            <Icon as={StarIcon} />
+            <Text>{score}</Text>
+          </HStack>
+        );
+      }}
+    >
+      <PopoverBackdrop />
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverBody>
+          <Text>Current score</Text>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/native/src/games/helpers/formatPlayers.ts
+++ b/apps/native/src/games/helpers/formatPlayers.ts
@@ -66,6 +66,8 @@ const formatPlayerMetadata = (
     score: calculatePlayerScore(playerData.scorePile, cards),
     resourceTotals: calculateResourceTotals(playerData.board, cards),
     possibleActions: determinePlayerPossibleActions(playerData, cards, deck),
+    numAchievements: playerData.ageAchievements.length,
+    numSpecialAchievements: playerData.specialAchievements.length,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11462,6 +11462,11 @@ lru-cache@^7.10.1, lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
+lucide-react-native@^0.503.0:
+  version "0.503.0"
+  resolved "https://registry.yarnpkg.com/lucide-react-native/-/lucide-react-native-0.503.0.tgz#d0ddef7007b097634c105c28dbf0e635cac144af"
+  integrity sha512-7KhfhLuvqSTMhZTlXxcDZK+4843c1mGlxBwd9pKf/zU4ye1l+n5iCrVo3Zz/D4uObwot0zrfxFOQEYx4M9zltg==
+
 magic-string@0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"


### PR DESCRIPTION
## Summary

- Added a drawer for showing player stats using Gluestack-UI components
- Multiple new display components added
- installed `lucide-react-native` icons library per [gluestack recommendation](https://gluestack.io/ui/docs/components/icon#lucide-icons-recommended)

## Demo


https://github.com/user-attachments/assets/399c63b7-5835-4152-bcaf-b99af85273f8

