### PR TITLE
cleanup card age constants & utils

### DIFF
--- a/apps/backend/src/cards/__mocks__/cards-sorting.mock.ts
+++ b/apps/backend/src/cards/__mocks__/cards-sorting.mock.ts
@@ -1,24 +1,26 @@
+import { Age } from '@inno/constants';
+
 import { CardRefsByAge } from '../dto/card-refs-by-age.dto';
 import { CardIdAndRefByAge } from '../dto/cardId-and-ref-by-age.dto';
 
 export const baseArrByAge = {
-  ONE: [],
-  TWO: [],
-  THREE: [],
-  FOUR: [],
-  FIVE: [],
-  SIX: [],
-  SEVEN: [],
-  EIGHT: [],
-  NINE: [],
-  TEN: [],
+  [Age.ONE]: [],
+  [Age.TWO]: [],
+  [Age.THREE]: [],
+  [Age.FOUR]: [],
+  [Age.FIVE]: [],
+  [Age.SIX]: [],
+  [Age.SEVEN]: [],
+  [Age.EIGHT]: [],
+  [Age.NINE]: [],
+  [Age.TEN]: [],
 };
 
 export const MOCK_CARD_REFS_BY_AGE: CardRefsByAge = Object.assign(
   {},
   {
     ...baseArrByAge,
-    ONE: [
+    [Age.ONE]: [
       'MOCK_REF-ONE-0',
       'MOCK_REF-ONE-1',
       'MOCK_REF-ONE-2',
@@ -26,7 +28,7 @@ export const MOCK_CARD_REFS_BY_AGE: CardRefsByAge = Object.assign(
       'MOCK_REF-ONE-4',
       'MOCK_REF-ONE-5',
     ],
-    TWO: [
+    [Age.TWO]: [
       'MOCK_REF-TWO-0',
       'MOCK_REF-TWO-1',
       'MOCK_REF-TWO-2',
@@ -34,7 +36,7 @@ export const MOCK_CARD_REFS_BY_AGE: CardRefsByAge = Object.assign(
       'MOCK_REF-TWO-4',
       'MOCK_REF-TWO-5',
     ],
-    EIGHT: [
+    [Age.EIGHT]: [
       'MOCK_REF-EIGHT-0',
       'MOCK_REF-EIGHT-1',
       'MOCK_REF-EIGHT-2',
@@ -49,12 +51,12 @@ export const MOCK_CARD_ID_AND_REF_BY_AGE: CardIdAndRefByAge = Object.assign(
   {},
   {
     ...baseArrByAge,
-    ONE: [
+    [Age.ONE]: [
       { cardId: 'MOCK_CARD_ID-ONE-0', ref: 'MOCK_ID-ONE-0' },
       { cardId: 'MOCK_CARD_ID-ONE-1', ref: 'MOCK_ID-ONE-1' },
     ],
-    TWO: [{ cardId: 'MOCK_CARD_ID-TWO-0', ref: 'MOCK_ID-TWO-0' }],
-    EIGHT: [
+    [Age.TWO]: [{ cardId: 'MOCK_CARD_ID-TWO-0', ref: 'MOCK_ID-TWO-0' }],
+    [Age.EIGHT]: [
       { cardId: 'MOCK_CARD_ID-EIGHT-0', ref: 'MOCK_ID-EIGHT-0' },
       { cardId: 'MOCK_CARD_ID-EIGHT-1', ref: 'MOCK_ID-EIGHT-1' },
       { cardId: 'MOCK_CARD_ID-EIGHT-2', ref: 'MOCK_ID-EIGHT-2' },

--- a/apps/backend/src/cards/dto/card-refs-by-age.dto.ts
+++ b/apps/backend/src/cards/dto/card-refs-by-age.dto.ts
@@ -1,36 +1,36 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { AgeString } from '@inno/constants';
+import { Age } from '@inno/constants';
 
 @ObjectType()
 export class CardRefsByAge {
   @Field(() => [String])
-  [AgeString.ONE]!: string[]; // NOTE: need the ! due to this: https://github.com/Microsoft/TypeScript-Vue-Starter/issues/36#issuecomment-371434263
+  [Age.ONE]!: string[]; // NOTE: need the ! due to this: https://github.com/Microsoft/TypeScript-Vue-Starter/issues/36#issuecomment-371434263
 
   @Field(() => [String])
-  [AgeString.TWO]!: string[];
+  [Age.TWO]!: string[];
 
   @Field(() => [String])
-  [AgeString.THREE]!: string[];
+  [Age.THREE]!: string[];
 
   @Field(() => [String])
-  [AgeString.FOUR]!: string[];
+  [Age.FOUR]!: string[];
 
   @Field(() => [String])
-  [AgeString.FIVE]!: string[];
+  [Age.FIVE]!: string[];
 
   @Field(() => [String])
-  [AgeString.SIX]!: string[];
+  [Age.SIX]!: string[];
 
   @Field(() => [String])
-  [AgeString.SEVEN]!: string[];
+  [Age.SEVEN]!: string[];
 
   @Field(() => [String])
-  [AgeString.EIGHT]!: string[];
+  [Age.EIGHT]!: string[];
 
   @Field(() => [String])
-  [AgeString.NINE]!: string[];
+  [Age.NINE]!: string[];
 
   @Field(() => [String])
-  [AgeString.TEN]!: string[];
+  [Age.TEN]!: string[];
 }

--- a/apps/backend/src/cards/dto/cardId-and-ref-by-age.dto.ts
+++ b/apps/backend/src/cards/dto/cardId-and-ref-by-age.dto.ts
@@ -1,36 +1,38 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
+import { Age } from '@inno/constants';
+
 import { CardIdAndRef } from './cardId-and-ref.dto';
 
 @ObjectType()
 export class CardIdAndRefByAge {
   @Field(() => [CardIdAndRef])
-  ONE!: CardIdAndRef[];
+  [Age.ONE]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  TWO!: CardIdAndRef[];
+  [Age.TWO]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  THREE!: CardIdAndRef[];
+  [Age.THREE]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  FOUR!: CardIdAndRef[];
+  [Age.FOUR]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  FIVE!: CardIdAndRef[];
+  [Age.FIVE]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  SIX!: CardIdAndRef[];
+  [Age.SIX]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  SEVEN!: CardIdAndRef[];
+  [Age.SEVEN]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  EIGHT!: CardIdAndRef[];
+  [Age.EIGHT]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  NINE!: CardIdAndRef[];
+  [Age.NINE]!: CardIdAndRef[];
 
   @Field(() => [CardIdAndRef])
-  TEN!: CardIdAndRef[];
+  [Age.TEN]!: CardIdAndRef[];
 }

--- a/apps/backend/src/cards/services/cards-sorting.service.ts
+++ b/apps/backend/src/cards/services/cards-sorting.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { AgeString, cardAgeToAgeStringMap } from '@inno/constants';
+import { Age, AgeDataByAgeNum, AgeNum } from '@inno/constants';
 
 import { CardRefsByAge } from '../dto/card-refs-by-age.dto';
 import { CardIdAndRefByAge } from '../dto/cardId-and-ref-by-age.dto';
@@ -10,42 +10,44 @@ import { Card } from '../schemas/card.schema';
 export class CardsSortingService {
   refsByAge({ cards }: { cards: Card[] }): CardRefsByAge {
     const baseObject: CardRefsByAge = {
-      [AgeString.ONE]: [],
-      [AgeString.TWO]: [],
-      [AgeString.THREE]: [],
-      [AgeString.FOUR]: [],
-      [AgeString.FIVE]: [],
-      [AgeString.SIX]: [],
-      [AgeString.SEVEN]: [],
-      [AgeString.EIGHT]: [],
-      [AgeString.NINE]: [],
-      [AgeString.TEN]: [],
+      [Age.ONE]: [],
+      [Age.TWO]: [],
+      [Age.THREE]: [],
+      [Age.FOUR]: [],
+      [Age.FIVE]: [],
+      [Age.SIX]: [],
+      [Age.SEVEN]: [],
+      [Age.EIGHT]: [],
+      [Age.NINE]: [],
+      [Age.TEN]: [],
     };
     return cards.reduce((acc, card) => {
-      acc[cardAgeToAgeStringMap[card.age]].push(card._id);
+      const cardAgeStr = AgeDataByAgeNum[card.age as AgeNum].str;
+      acc[cardAgeStr].push(card._id);
       return acc;
     }, baseObject);
   }
 
   cardIdAndRefByAge({ cards }: { cards: Card[] }): CardIdAndRefByAge {
     const baseObject: CardIdAndRefByAge = {
-      [AgeString.ONE]: [],
-      [AgeString.TWO]: [],
-      [AgeString.THREE]: [],
-      [AgeString.FOUR]: [],
-      [AgeString.FIVE]: [],
-      [AgeString.SIX]: [],
-      [AgeString.SEVEN]: [],
-      [AgeString.EIGHT]: [],
-      [AgeString.NINE]: [],
-      [AgeString.TEN]: [],
+      [Age.ONE]: [],
+      [Age.TWO]: [],
+      [Age.THREE]: [],
+      [Age.FOUR]: [],
+      [Age.FIVE]: [],
+      [Age.SIX]: [],
+      [Age.SEVEN]: [],
+      [Age.EIGHT]: [],
+      [Age.NINE]: [],
+      [Age.TEN]: [],
     };
     return cards.reduce((acc, card) => {
       const cardDataToReturn = {
         cardId: card.cardId,
         ref: card._id,
       };
-      acc[cardAgeToAgeStringMap[card.age]].push(cardDataToReturn);
+      const cardAgeStr = AgeDataByAgeNum[card.age as AgeNum].str;
+      acc[cardAgeStr].push(cardDataToReturn);
       return acc;
     }, baseObject);
   }

--- a/apps/backend/src/gameplay/__tests__/new-game.helpers.spec.ts
+++ b/apps/backend/src/gameplay/__tests__/new-game.helpers.spec.ts
@@ -1,4 +1,4 @@
-import { AgeString } from '@inno/constants';
+import { Age } from '@inno/constants';
 
 import { MOCK_CARD_REFS_BY_AGE } from 'src/cards/__mocks__/cards-sorting.mock';
 import { MOCK_DECK } from 'src/games/__mocks__/deck.mock';
@@ -37,7 +37,7 @@ describe('pickAgeAchievements', () => {
 
   it('should return one card per age sorted by age', () => {
     Object.entries(ageAchievements).forEach(([age, card]) => {
-      const cardIsCorrectAge = MOCK_DECK[age as AgeString].includes(card as string);
+      const cardIsCorrectAge = MOCK_DECK[age as unknown as Age].includes(card as string);
       expect(cardIsCorrectAge).toBe(true);
     });
   });
@@ -51,13 +51,13 @@ describe('pickAgeAchievements', () => {
   });
 
   it('should not remove any TEN age cards from deck', () => {
-    expect(deckMinusAchievements.TEN).toEqual(MOCK_DECK.TEN);
+    expect(deckMinusAchievements[Age.TEN]).toEqual(MOCK_DECK[Age.TEN]);
   });
 
   it('should throw error if no achievement card available', () => {
     const output = () =>
       pickAgeAchievements({
-        ONE: [] as string[],
+        [Age.ONE]: [] as string[],
       } as Deck);
     expect(output).toThrow('Missing cardId for age achievements draw');
   });
@@ -78,7 +78,7 @@ describe('selectStarterHandsForPlayers', () => {
   it('should select ONE age cards only', () => {
     const flattenedPlayerStarterHands = Object.values(playerStarterHands).flat();
     flattenedPlayerStarterHands.forEach((card) => {
-      expect(MOCK_DECK.ONE.includes(card)).toBe(true);
+      expect(MOCK_DECK[Age.ONE].includes(card)).toBe(true);
     });
   });
 

--- a/apps/backend/src/gameplay/helpers/new-game.ts
+++ b/apps/backend/src/gameplay/helpers/new-game.ts
@@ -1,4 +1,4 @@
-import { AgeString, ages } from '@inno/constants';
+import { Age, AgeData } from '@inno/constants';
 import { shuffleArray } from '@inno/utils';
 
 import { CardRefsByAge } from 'src/cards/dto/card-refs-by-age.dto';
@@ -10,16 +10,15 @@ export type TPlayerStarterHands = {
 };
 
 export const cloneDeck = (baseDeck: Deck): Deck => {
-  return Object.keys(baseDeck).reduce((acc, age) => {
-    acc[age as AgeString] = [...baseDeck[age as AgeString]];
+  return Object.keys(baseDeck).reduce((acc, age: unknown) => {
+    acc[age as Age] = [...baseDeck[age as Age]];
     return acc;
   }, {} as Deck);
 };
 
 export const shuffleDeck = (cardRefsByAge: CardRefsByAge): Deck =>
-  Object.keys(cardRefsByAge).reduce((acc, ageString) => {
-    const age = ageString as AgeString;
-    acc[age] = shuffleArray(cardRefsByAge[age]) as string[];
+  Object.keys(cardRefsByAge).reduce((acc, age: unknown) => {
+    acc[age as Age] = shuffleArray(cardRefsByAge[age as Age]) as string[];
     return acc;
   }, {} as Deck);
 
@@ -27,13 +26,13 @@ export const pickAgeAchievements = (
   currentDeck: Deck
 ): { ageAchievements: AgeAchievements; deckMinusAchievements: Deck } => {
   const deckMinusAchievements = cloneDeck(currentDeck);
-  const ageAchievements = ages.reduce((acc, age) => {
-    if (age !== AgeString.TEN) {
-      const cardId = deckMinusAchievements[age].shift();
+  const ageAchievements = AgeData.reduce((acc, ageItem) => {
+    if (ageItem.str !== Age.TEN) {
+      const cardId = deckMinusAchievements[ageItem.str].shift();
       if (!cardId) {
         throw new Error('Missing cardId for age achievements draw');
       }
-      acc[age] = cardId;
+      acc[ageItem.str] = cardId;
     }
     return acc;
   }, {} as AgeAchievements);
@@ -51,7 +50,7 @@ export const selectStarterHandsForPlayers = (
   }, {} as TPlayerStarterHands);
   for (let i = 0; i < 2; i++) {
     Object.keys(playerStarterHands).forEach((playerId) => {
-      const cardId = deckMinusStarterHands[AgeString.ONE].shift();
+      const cardId = deckMinusStarterHands[Age.ONE].shift();
       if (!cardId) {
         throw new Error('Missing cardId for starter hands draw');
       }

--- a/apps/backend/src/games/__mocks__/age-achievements.mock.ts
+++ b/apps/backend/src/games/__mocks__/age-achievements.mock.ts
@@ -1,15 +1,17 @@
+import { Age } from '@inno/constants';
+
 import { AgeAchievements } from '../schemas/age-achievements.schema';
 
 export const MOCK_STARTER_AGE_ACHIEVEMENTS: AgeAchievements = {
-  ONE: '6435a7d5dd31b5790f7bc58a',
-  TWO: '6435a7d5dd31b5790f7bc59b',
-  THREE: '6435a7d5dd31b5790f7bc5a4',
-  FOUR: '6435a7d5dd31b5790f7bc5ad',
-  FIVE: '6435a7d5dd31b5790f7bc5bb',
-  SIX: '6435a7d5dd31b5790f7bc5bf',
-  SEVEN: '6435a7d5dd31b5790f7bc5ce',
-  EIGHT: '6435a7d5dd31b5790f7bc5d3',
-  NINE: '6435a7d5dd31b5790f7bc5e4',
+  [Age.ONE]: '6435a7d5dd31b5790f7bc58a',
+  [Age.TWO]: '6435a7d5dd31b5790f7bc59b',
+  [Age.THREE]: '6435a7d5dd31b5790f7bc5a4',
+  [Age.FOUR]: '6435a7d5dd31b5790f7bc5ad',
+  [Age.FIVE]: '6435a7d5dd31b5790f7bc5bb',
+  [Age.SIX]: '6435a7d5dd31b5790f7bc5bf',
+  [Age.SEVEN]: '6435a7d5dd31b5790f7bc5ce',
+  [Age.EIGHT]: '6435a7d5dd31b5790f7bc5d3',
+  [Age.NINE]: '6435a7d5dd31b5790f7bc5e4',
 };
 
 export const MOCK_PLAYER_AGE_ACHIEVEMENT_CARD_REF = 'mock-achievement-card-ref';

--- a/apps/backend/src/games/__mocks__/deck.mock.ts
+++ b/apps/backend/src/games/__mocks__/deck.mock.ts
@@ -1,7 +1,9 @@
+import { Age } from '@inno/constants';
+
 import { Deck } from '../schemas/deck.schema';
 
 export const MOCK_DECK: Deck = {
-  ONE: [
+  [Age.ONE]: [
     '6435a7d5dd31b5790f7bc587',
     '6435a7d5dd31b5790f7bc58e',
     '6435a7d5dd31b5790f7bc58d',
@@ -13,7 +15,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc591',
     '6435a7d5dd31b5790f7bc588',
   ],
-  TWO: [
+  [Age.TWO]: [
     '6435a7d5dd31b5790f7bc599',
     '6435a7d5dd31b5790f7bc59a',
     '6435a7d5dd31b5790f7bc59d',
@@ -24,7 +26,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc598',
     '6435a7d5dd31b5790f7bc59e',
   ],
-  THREE: [
+  [Age.THREE]: [
     '6435a7d5dd31b5790f7bc5a0',
     '6435a7d5dd31b5790f7bc5a7',
     '6435a7d5dd31b5790f7bc5a1',
@@ -35,7 +37,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5a2',
     '6435a7d5dd31b5790f7bc5a8',
   ],
-  FOUR: [
+  [Age.FOUR]: [
     '6435a7d5dd31b5790f7bc5af',
     '6435a7d5dd31b5790f7bc5b1',
     '6435a7d5dd31b5790f7bc5aa',
@@ -46,7 +48,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5ac',
     '6435a7d5dd31b5790f7bc5b0',
   ],
-  FIVE: [
+  [Age.FIVE]: [
     '6435a7d5dd31b5790f7bc5b5',
     '6435a7d5dd31b5790f7bc5bc',
     '6435a7d5dd31b5790f7bc5ba',
@@ -57,7 +59,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5b8',
     '6435a7d5dd31b5790f7bc5b4',
   ],
-  SIX: [
+  [Age.SIX]: [
     '6435a7d5dd31b5790f7bc5c0',
     '6435a7d5dd31b5790f7bc5c4',
     '6435a7d5dd31b5790f7bc5c1',
@@ -68,7 +70,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5be',
     '6435a7d5dd31b5790f7bc5c7',
   ],
-  SEVEN: [
+  [Age.SEVEN]: [
     '6435a7d5dd31b5790f7bc5d0',
     '6435a7d5dd31b5790f7bc5cd',
     '6435a7d5dd31b5790f7bc5d1',
@@ -79,7 +81,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5c8',
     '6435a7d5dd31b5790f7bc5cf',
   ],
-  EIGHT: [
+  [Age.EIGHT]: [
     '6435a7d5dd31b5790f7bc5d9',
     '6435a7d5dd31b5790f7bc5d4',
     '6435a7d5dd31b5790f7bc5d6',
@@ -90,7 +92,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5d7',
     '6435a7d5dd31b5790f7bc5d2',
   ],
-  NINE: [
+  [Age.NINE]: [
     '6435a7d5dd31b5790f7bc5dc',
     '6435a7d5dd31b5790f7bc5e1',
     '6435a7d5dd31b5790f7bc5e0',
@@ -101,7 +103,7 @@ export const MOCK_DECK: Deck = {
     '6435a7d5dd31b5790f7bc5e2',
     '6435a7d5dd31b5790f7bc5e3',
   ],
-  TEN: [
+  [Age.TEN]: [
     '6435a7d5dd31b5790f7bc5e7',
     '6435a7d5dd31b5790f7bc5ef',
     '6435a7d5dd31b5790f7bc5e9',

--- a/apps/backend/src/games/__mocks__/game.mock.ts
+++ b/apps/backend/src/games/__mocks__/game.mock.ts
@@ -1,4 +1,4 @@
-import { GameStage } from '@inno/constants';
+import { Age, GameStage } from '@inno/constants';
 
 import { MOCK_ROOM_ID } from 'src/rooms/__mocks__/room.mock';
 import { MOCK_USER_ID, MOCK_USER_ID_2 } from 'src/users/__mocks__/user.mock';
@@ -17,15 +17,15 @@ export const MOCK_GAME_INPUT: CreateGameInput = {
   playerRefs: [MOCK_USER_ID, MOCK_USER_ID_2],
   deck: MOCK_DECK,
   ageAchievements: {
-    ONE: '6435a7d5dd31b5790f7bc58a',
-    TWO: '6435a7d5dd31b5790f7bc59b',
-    THREE: '6435a7d5dd31b5790f7bc5a4',
-    FOUR: '6435a7d5dd31b5790f7bc5ad',
-    FIVE: '6435a7d5dd31b5790f7bc5bb',
-    SIX: '6435a7d5dd31b5790f7bc5bf',
-    SEVEN: '6435a7d5dd31b5790f7bc5ce',
-    EIGHT: '6435a7d5dd31b5790f7bc5d3',
-    NINE: '6435a7d5dd31b5790f7bc5e4',
+    [Age.ONE]: '6435a7d5dd31b5790f7bc58a',
+    [Age.TWO]: '6435a7d5dd31b5790f7bc59b',
+    [Age.THREE]: '6435a7d5dd31b5790f7bc5a4',
+    [Age.FOUR]: '6435a7d5dd31b5790f7bc5ad',
+    [Age.FIVE]: '6435a7d5dd31b5790f7bc5bb',
+    [Age.SIX]: '6435a7d5dd31b5790f7bc5bf',
+    [Age.SEVEN]: '6435a7d5dd31b5790f7bc5ce',
+    [Age.EIGHT]: '6435a7d5dd31b5790f7bc5d3',
+    [Age.NINE]: '6435a7d5dd31b5790f7bc5e4',
   },
 };
 
@@ -40,15 +40,15 @@ export const MOCK_GAME: Game = {
   playerRefs: [MOCK_USER_ID, MOCK_USER_ID_2],
   deck: MOCK_DECK,
   ageAchievements: {
-    ONE: '6435a7d5dd31b5790f7bc58a',
-    TWO: '6435a7d5dd31b5790f7bc59b',
-    THREE: '6435a7d5dd31b5790f7bc5a4',
-    FOUR: '6435a7d5dd31b5790f7bc5ad',
-    FIVE: '6435a7d5dd31b5790f7bc5bb',
-    SIX: '6435a7d5dd31b5790f7bc5bf',
-    SEVEN: '6435a7d5dd31b5790f7bc5ce',
-    EIGHT: '6435a7d5dd31b5790f7bc5d3',
-    NINE: '6435a7d5dd31b5790f7bc5e4',
+    [Age.ONE]: '6435a7d5dd31b5790f7bc58a',
+    [Age.TWO]: '6435a7d5dd31b5790f7bc59b',
+    [Age.THREE]: '6435a7d5dd31b5790f7bc5a4',
+    [Age.FOUR]: '6435a7d5dd31b5790f7bc5ad',
+    [Age.FIVE]: '6435a7d5dd31b5790f7bc5bb',
+    [Age.SIX]: '6435a7d5dd31b5790f7bc5bf',
+    [Age.SEVEN]: '6435a7d5dd31b5790f7bc5ce',
+    [Age.EIGHT]: '6435a7d5dd31b5790f7bc5d3',
+    [Age.NINE]: '6435a7d5dd31b5790f7bc5e4',
   },
   winnerRef: undefined,
 };

--- a/apps/backend/src/games/schemas/age-achievements.schema.ts
+++ b/apps/backend/src/games/schemas/age-achievements.schema.ts
@@ -2,6 +2,8 @@ import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema } from '@nestjs/mongoose';
 import { Schema as MongooseSchema } from 'mongoose';
 
+import { Age } from '@inno/constants';
+
 @Schema({ _id: false })
 @ObjectType()
 @InputType('AgeAchievementsInput')
@@ -11,61 +13,61 @@ export class AgeAchievements {
     ref: 'Card',
   })
   @Field(() => ID)
-  ONE!: string;
+  [Age.ONE]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  TWO!: string;
+  [Age.TWO]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  THREE!: string;
+  [Age.THREE]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  FOUR!: string;
+  [Age.FOUR]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  FIVE!: string;
+  [Age.FIVE]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  SIX!: string;
+  [Age.SIX]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  SEVEN!: string;
+  [Age.SEVEN]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  EIGHT!: string;
+  [Age.EIGHT]!: string;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Card',
   })
   @Field(() => ID)
-  NINE!: string;
+  [Age.NINE]!: string;
 }

--- a/apps/backend/src/games/schemas/deck.schema.ts
+++ b/apps/backend/src/games/schemas/deck.schema.ts
@@ -2,7 +2,7 @@ import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema } from '@nestjs/mongoose';
 import { Schema as MongooseSchema } from 'mongoose';
 
-import { AgeString } from '@inno/constants';
+import { Age } from '@inno/constants';
 
 @Schema({ _id: false })
 @ObjectType()
@@ -14,7 +14,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.ONE]!: string[];
+  [Age.ONE]!: string[];
 
   @Prop({
     required: true,
@@ -22,7 +22,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.TWO]!: string[];
+  [Age.TWO]!: string[];
 
   @Prop({
     required: true,
@@ -30,7 +30,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.THREE]!: string[];
+  [Age.THREE]!: string[];
 
   @Prop({
     required: true,
@@ -38,7 +38,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.FOUR]!: string[];
+  [Age.FOUR]!: string[];
 
   @Prop({
     required: true,
@@ -46,7 +46,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.FIVE]!: string[];
+  [Age.FIVE]!: string[];
 
   @Prop({
     required: true,
@@ -54,7 +54,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.SIX]!: string[];
+  [Age.SIX]!: string[];
 
   @Prop({
     required: true,
@@ -62,7 +62,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.SEVEN]!: string[];
+  [Age.SEVEN]!: string[];
 
   @Prop({
     required: true,
@@ -70,7 +70,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.EIGHT]!: string[];
+  [Age.EIGHT]!: string[];
 
   @Prop({
     required: true,
@@ -78,7 +78,7 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.NINE]!: string[];
+  [Age.NINE]!: string[];
 
   @Prop({
     required: true,
@@ -86,5 +86,5 @@ export class Deck {
     ref: 'Card',
   })
   @Field(() => [ID])
-  [AgeString.TEN]!: string[];
+  [Age.TEN]!: string[];
 }

--- a/apps/native/src/app-core/types/game.types.ts
+++ b/apps/native/src/app-core/types/game.types.ts
@@ -1,4 +1,4 @@
-import { ActionNumber, AgeString, GameStage, Nullable } from '@inno/constants';
+import { ActionNumber, Age, GameStage, IAgeDataItem, Nullable } from '@inno/constants';
 import { BoardPile as GQLBoardPile, Board as GQLBoard, Deck as GQLDeck, Card } from '@inno/gql';
 
 export enum AgeAchievementKey {
@@ -155,15 +155,16 @@ export enum Resource {
 export type ResourceTotals = Record<ResourceId, number>;
 
 export type PossibleActions = {
-  draw: Nullable<AgeString>;
+  draw: Nullable<Age>;
   meld: string[];
   dogma: string[];
+  achieve: string[];
 };
 
 export type ResourceId = keyof typeof Resource;
 
 export type PlayerMetadata = {
-  age: number;
+  age: IAgeDataItem;
   score: number;
   resourceTotals: ResourceTotals;
   possibleActions: PossibleActions;
@@ -173,7 +174,9 @@ export type PlayerMetadata = {
 
 export type BoardPile = Omit<GQLBoardPile, '__typename'>;
 
-export type Board = Record<keyof Omit<GQLBoard, '__typename'>, BoardPile>;
+export type BoardKey = keyof Omit<GQLBoard, '__typename'>;
+
+export type Board = Record<BoardKey, BoardPile>;
 
 export type Boards = Record<string, Board>;
 

--- a/apps/native/src/cards/components/back/AchievementCost.tsx
+++ b/apps/native/src/cards/components/back/AchievementCost.tsx
@@ -1,15 +1,14 @@
-import { AgeString, ageCostToAchieveMap } from '@inno/constants';
+import { AgeAchievementCost, Nullable } from '@inno/constants';
 
 import { Box } from '../../../app-core/components/gluestack/box';
 import { Text } from '../../../app-core/components/gluestack/text';
 import { CARD_BACK_COLOR_DARK, CARD_BACK_COLOR_LIGHT } from '../../../app-core/constants/colors';
 
 export interface IAchievementCostProps {
-  age: AgeString;
+  cost: Nullable<AgeAchievementCost>;
 }
 
-export const AchievementCost = ({ age }: IAchievementCostProps) => {
-  const cost = ageCostToAchieveMap[age];
+export const AchievementCost = ({ cost }: IAchievementCostProps) => {
   if (!cost) {
     return null;
   }

--- a/apps/native/src/cards/components/back/CardBack.tsx
+++ b/apps/native/src/cards/components/back/CardBack.tsx
@@ -1,4 +1,4 @@
-import { ageStringToAgeNameMap, cardAgeToAgeStringMap } from '@inno/constants';
+import { AgeDataByAgeNum, AgeNum } from '@inno/constants';
 
 import { Box } from '../../../app-core/components/gluestack/box';
 import { HStack } from '../../../app-core/components/gluestack/hstack';
@@ -13,12 +13,11 @@ import { AchievementCost } from './AchievementCost';
 import { CardAgeBack } from './CardAgeBack';
 
 export interface ICardBackProps {
-  age: number;
+  age: AgeNum;
 }
 
 export const CardBack = ({ age }: ICardBackProps) => {
-  const ageStr = cardAgeToAgeStringMap[age];
-  const ageName = ageStringToAgeNameMap[ageStr];
+  const ageDataItem = AgeDataByAgeNum[age];
   return (
     <Box
       style={{
@@ -54,10 +53,10 @@ export const CardBack = ({ age }: ICardBackProps) => {
           }}
           className={` font-bold self-center `}
         >
-          {ageName}
+          {ageDataItem.name}
         </Text>
         <Box className="pb-3 pr-2 self-end">
-          <AchievementCost age={ageStr} />
+          <AchievementCost cost={ageDataItem.costToAchieve} />
         </Box>
       </Box>
     </Box>

--- a/apps/native/src/deck/components/DeckLayout.tsx
+++ b/apps/native/src/deck/components/DeckLayout.tsx
@@ -1,6 +1,6 @@
 import { FlatList, ListRenderItemInfo } from 'react-native';
 
-import { AgeString, ageStringToAgeNumberMap } from '@inno/constants';
+import { Age, AgeDataByAgeStr } from '@inno/constants';
 
 import { BadgeType, CountBadge } from '../../app-core/components/CountBadge';
 import { MaybePressable } from '../../app-core/components/MaybePressable';
@@ -9,7 +9,7 @@ import { VerticalEmptyCardSlot } from '../../cards/components/VerticalEmptyCardS
 import { CardBack } from '../../cards/components/back/CardBack';
 
 export interface IDeckPileMetadata {
-  age: AgeString;
+  age: Age;
   numCardsInPile: number;
   availableToDraw: boolean;
   onDraw?(): void;
@@ -26,7 +26,7 @@ export const DeckLayout = ({ deckMetadata }: IDeckLayoutProps) => {
     <FlatList
       data={deckMetadata}
       renderItem={({ item: pile }: ListRenderItemInfo<IDeckPileMetadata>) => {
-        const ageNum = ageStringToAgeNumberMap[pile.age];
+        const ageNum = AgeDataByAgeStr[pile.age].num;
         return pile.numCardsInPile ? (
           <MaybePressable
             handlePress={pile.availableToDraw && pile.onDraw ? pile.onDraw : undefined}

--- a/apps/native/src/deck/helpers/whichDrawPile.ts
+++ b/apps/native/src/deck/helpers/whichDrawPile.ts
@@ -1,20 +1,22 @@
-import { ages, AgeString } from '@inno/constants';
+import { Age } from '@inno/constants';
 import { Deck } from '@inno/gql';
 
 interface IWhichDrawPileProps {
   deck: Deck;
-  currentPlayerAge: AgeString;
+  currentPlayerAge: Age;
 }
 
 export const whichDrawPile = ({ deck, currentPlayerAge }: IWhichDrawPileProps) => {
   if (deck[currentPlayerAge].length) {
     return currentPlayerAge;
   }
-  const ageIdx = ages.indexOf(currentPlayerAge);
-  const remainingAges = ages.slice(ageIdx + 1);
+  const deckAges = Object.keys(deck) as Age[];
+  const ageIdx = deckAges.indexOf(currentPlayerAge);
+  const remainingAges = deckAges.slice(ageIdx + 1);
   for (let i = 0; i <= remainingAges.length; i++) {
     if (deck[remainingAges[i]].length) {
       return remainingAges[i];
     }
   }
+  return null;
 };

--- a/apps/native/src/deck/hooks/useDeckMetadata.ts
+++ b/apps/native/src/deck/hooks/useDeckMetadata.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { AgeString } from '@inno/constants';
+import { Age } from '@inno/constants';
 import { Deck } from '@inno/gql';
 
 import { IDeckPileMetadata } from '../components/DeckLayout';
@@ -10,20 +10,20 @@ interface IUseDeckMetadataProps {
 }
 
 export const useDeckMetadata = ({ deck }: IUseDeckMetadataProps) => {
-  const handleDraw = useCallback(({ age, player }: { age: AgeString; player: string }) => {
+  const handleDraw = useCallback(({ age, player }: { age: Age; player: string }) => {
     console.log(`ready to draw ${age} age for ${player}`);
     // TODO: add actual draw logic here
   }, []);
 
   const deckMetadata = useMemo(() => {
     return Object.keys(deck).reduce((acc, key) => {
-      const maybeAge = key as AgeString;
-      if (AgeString[maybeAge]) {
+      const maybeAge = key as Age;
+      if (Age[maybeAge]) {
         acc.push({
           age: maybeAge,
           numCardsInPile: deck[key as keyof Deck]?.length ?? 0,
           // TODO: pull actual current game data for this
-          availableToDraw: maybeAge === AgeString.ONE,
+          availableToDraw: maybeAge === Age.ONE,
           // TODO: pull actual current player data for this
           onDraw: () => handleDraw({ age: maybeAge, player: 'TESTING' }),
         });

--- a/packages/constants/src/cards.ts
+++ b/packages/constants/src/cards.ts
@@ -1,4 +1,6 @@
-export enum AgeString {
+import { Nullable } from './typeUtils';
+
+export enum Age {
   ONE = 'ONE',
   TWO = 'TWO',
   THREE = 'THREE',
@@ -11,44 +13,43 @@ export enum AgeString {
   TEN = 'TEN',
 }
 
-export enum AgeName {
-  PREHISTORY = 'PREHISTORY',
-  CLASSICAL = 'CLASSICAL',
-  MEDIEVAL = 'MEDIEVAL',
-  RENAISSANCE = 'RENAISSANCE',
-  EXPLORATION = 'EXPLORATION',
-  ENLIGHTENMENT = 'ENLIGHTENMENT',
-  ROMANCE = 'ROMANCE',
-  MODERN = 'MODERN',
-  POSTMODERN = 'POSTMODERN',
-  INFORMATION = 'INFORMATION',
+export enum AgeNum {
+  ONE = 1,
+  TWO = 2,
+  THREE = 3,
+  FOUR = 4,
+  FIVE = 5,
+  SIX = 6,
+  SEVEN = 7,
+  EIGHT = 8,
+  NINE = 9,
+  TEN = 10,
 }
 
-export const ages = [
-  AgeString.ONE,
-  AgeString.TWO,
-  AgeString.THREE,
-  AgeString.FOUR,
-  AgeString.FIVE,
-  AgeString.SIX,
-  AgeString.SEVEN,
-  AgeString.EIGHT,
-  AgeString.NINE,
-  AgeString.TEN,
-];
+export enum AgeName {
+  ONE = 'PREHISTORY',
+  TWO = 'CLASSICAL',
+  THREE = 'MEDIEVAL',
+  FOUR = 'RENAISSANCE',
+  FIVE = 'EXPLORATION',
+  SIX = 'ENLIGHTENMENT',
+  SEVEN = 'ROMANCE',
+  EIGHT = 'MODERN',
+  NINE = 'POSTMODERN',
+  TEN = 'INFORMATION',
+}
 
-export const cardAgeToAgeStringMap: { [key: string]: AgeString } = {
-  1: AgeString.ONE,
-  2: AgeString.TWO,
-  3: AgeString.THREE,
-  4: AgeString.FOUR,
-  5: AgeString.FIVE,
-  6: AgeString.SIX,
-  7: AgeString.SEVEN,
-  8: AgeString.EIGHT,
-  9: AgeString.NINE,
-  10: AgeString.TEN,
-};
+export enum AgeAchievementCost {
+  ONE = 5,
+  TWO = 10,
+  THREE = 15,
+  FOUR = 20,
+  FIVE = 25,
+  SIX = 30,
+  SEVEN = 35,
+  EIGHT = 40,
+  NINE = 45,
+}
 
 export enum Resource {
   CASTLES = 'castles',
@@ -67,40 +68,85 @@ export enum Color {
   YELLOW = 'yellow',
 }
 
-export const ageStringToAgeNumberMap: { [key in AgeString]: number } = {
-  [AgeString.ONE]: 1,
-  [AgeString.TWO]: 2,
-  [AgeString.THREE]: 3,
-  [AgeString.FOUR]: 4,
-  [AgeString.FIVE]: 5,
-  [AgeString.SIX]: 6,
-  [AgeString.SEVEN]: 7,
-  [AgeString.EIGHT]: 8,
-  [AgeString.NINE]: 9,
-  [AgeString.TEN]: 10,
-};
+export interface IAgeDataItem {
+  num: AgeNum;
+  str: Age;
+  name: AgeName;
+  costToAchieve: Nullable<number>;
+}
 
-export const ageStringToAgeNameMap: { [key in AgeString]: AgeName } = {
-  [AgeString.ONE]: AgeName.PREHISTORY,
-  [AgeString.TWO]: AgeName.CLASSICAL,
-  [AgeString.THREE]: AgeName.MEDIEVAL,
-  [AgeString.FOUR]: AgeName.RENAISSANCE,
-  [AgeString.FIVE]: AgeName.EXPLORATION,
-  [AgeString.SIX]: AgeName.ENLIGHTENMENT,
-  [AgeString.SEVEN]: AgeName.ROMANCE,
-  [AgeString.EIGHT]: AgeName.MODERN,
-  [AgeString.NINE]: AgeName.POSTMODERN,
-  [AgeString.TEN]: AgeName.INFORMATION,
-};
+export const AgeData: IAgeDataItem[] = [
+  {
+    num: AgeNum.ONE,
+    str: Age.ONE,
+    name: AgeName[Age.ONE],
+    costToAchieve: AgeAchievementCost[Age.ONE],
+  },
+  {
+    num: AgeNum.TWO,
+    str: Age.TWO,
+    name: AgeName[Age.TWO],
+    costToAchieve: AgeAchievementCost[Age.TWO],
+  },
+  {
+    num: AgeNum.THREE,
+    str: Age.THREE,
+    name: AgeName[Age.THREE],
+    costToAchieve: AgeAchievementCost[Age.THREE],
+  },
+  {
+    num: AgeNum.FOUR,
+    str: Age.FOUR,
+    name: AgeName[Age.FOUR],
+    costToAchieve: AgeAchievementCost[Age.FOUR],
+  },
+  {
+    num: AgeNum.FIVE,
+    str: Age.FIVE,
+    name: AgeName[Age.FIVE],
+    costToAchieve: AgeAchievementCost[Age.FIVE],
+  },
+  {
+    num: AgeNum.SIX,
+    str: Age.SIX,
+    name: AgeName[Age.SIX],
+    costToAchieve: AgeAchievementCost[Age.SIX],
+  },
+  {
+    num: AgeNum.SEVEN,
+    str: Age.SEVEN,
+    name: AgeName[Age.SEVEN],
+    costToAchieve: AgeAchievementCost[Age.SEVEN],
+  },
+  {
+    num: AgeNum.EIGHT,
+    str: Age.EIGHT,
+    name: AgeName[Age.EIGHT],
+    costToAchieve: AgeAchievementCost[Age.EIGHT],
+  },
+  {
+    num: AgeNum.NINE,
+    str: Age.NINE,
+    name: AgeName[Age.NINE],
+    costToAchieve: AgeAchievementCost[Age.NINE],
+  },
+  {
+    num: AgeNum.TEN,
+    str: Age.TEN,
+    name: AgeName[Age.TEN],
+    costToAchieve: null,
+  },
+];
 
-export const ageCostToAchieveMap: { [key in AgeString]?: number } = {
-  [AgeString.ONE]: 5,
-  [AgeString.TWO]: 10,
-  [AgeString.THREE]: 15,
-  [AgeString.FOUR]: 20,
-  [AgeString.FIVE]: 25,
-  [AgeString.SIX]: 30,
-  [AgeString.SEVEN]: 35,
-  [AgeString.EIGHT]: 40,
-  [AgeString.NINE]: 45,
-};
+export type TAgeDataByAgeStr = { [key in Age]: IAgeDataItem };
+export type TAgeDataByAgeNum = { [key in AgeNum]: IAgeDataItem };
+
+export const AgeDataByAgeStr: TAgeDataByAgeStr = AgeData.reduce((acc, item) => {
+  acc[item.str] = item;
+  return acc;
+}, {} as TAgeDataByAgeStr);
+
+export const AgeDataByAgeNum: TAgeDataByAgeNum = AgeData.reduce((acc, item) => {
+  acc[item.num] = item;
+  return acc;
+}, {} as TAgeDataByAgeNum);


### PR DESCRIPTION
## Summary

- cleaned up logic around Age name/number/string etc

## Details
Age is slightly complicated because we cannot use number as the property for GraphQL data. Therefore we use the string name of the number for storing card / player age data (ex. `ONE` instead of `1`). This makes things annoyingly complicated when trying to map stored age string data vs. card age number data and then age _names_ on top of that. Previously there were a lot of different maps being maintained for each of these. Instead, we now have a single SoT map for:
- age number, age string, age name, and cost to achieve