### PR TITLE
Feature: Meld Logic

### DIFF
--- a/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
+++ b/apps/backend/src/gameplay/__mocks__/gameplay.mock.ts
@@ -42,6 +42,7 @@ export const MOCK_NEW_GAME_RESPONSE: CreateNewGameResponse = {
 export const MOCK_MELD_FROM_HAND_INPUT: MeldInput = {
   cardRef: MOCK_PLAYER_GAME_DETAILS.hand[0],
   gameRef: MOCK_GAME._id,
+  countAsAction: false,
   isStarterMeld: false,
   playerRef: MOCK_PLAYER_GAME_DETAILS.playerRef,
   meldType: 'fromHand',

--- a/apps/backend/src/gameplay/__tests__/gameplay.resolver.spec.ts
+++ b/apps/backend/src/gameplay/__tests__/gameplay.resolver.spec.ts
@@ -124,13 +124,13 @@ describe('GameplayResolver', () => {
     });
     describe('meld', () => {
       it('should return output of running meldCardFromHand when meldType is "fromHand"', async () => {
-        const playerActionsServiceSpy = jest
+        const meldCardFromHandSpy = jest
           .spyOn(playerActionsService, 'meldCardFromHand')
           .mockResolvedValueOnce(MOCK_MELD_FROM_HAND_RESPONSE);
 
         const output = await gameplayResolver.meld(MOCK_MELD_FROM_HAND_INPUT);
 
-        expect(playerActionsServiceSpy).toHaveBeenCalledWith({
+        expect(meldCardFromHandSpy).toHaveBeenCalledWith({
           cardId: MOCK_MELD_FROM_HAND_INPUT.cardRef,
           gameId: MOCK_MELD_FROM_HAND_INPUT.gameRef,
           playerId: MOCK_MELD_FROM_HAND_INPUT.playerRef,
@@ -140,6 +140,7 @@ describe('GameplayResolver', () => {
           playerId: MOCK_MELD_FROM_HAND_INPUT.playerRef,
           updatedPlayerBoard: MOCK_MELD_FROM_HAND_RESPONSE.updatedPlayerBoard,
           metadata: {
+            currentActionUpdated: false,
             gameStageUpdated: false,
             updatedPlayerHand: MOCK_MELD_FROM_HAND_RESPONSE.updatedPlayerHand,
           },

--- a/apps/backend/src/gameplay/dto/meld.input.dto.ts
+++ b/apps/backend/src/gameplay/dto/meld.input.dto.ts
@@ -18,4 +18,7 @@ export class MeldInput {
 
   @Field(() => Boolean)
   isStarterMeld!: boolean;
+
+  @Field(() => Boolean)
+  countAsAction!: boolean;
 }

--- a/apps/backend/src/gameplay/dto/meld.output.dto.ts
+++ b/apps/backend/src/gameplay/dto/meld.output.dto.ts
@@ -10,6 +10,12 @@ export class MeldResponseMetadata {
 
   @Field(() => Deck)
   updatedDeck?: Deck;
+
+  @Field(() => Boolean)
+  gameStageUpdated?: boolean;
+
+  @Field(() => Boolean)
+  currentActionUpdated?: boolean;
 }
 
 @ObjectType()

--- a/apps/backend/src/gameplay/gameplay.resolver.ts
+++ b/apps/backend/src/gameplay/gameplay.resolver.ts
@@ -49,6 +49,7 @@ export class GameplayResolver {
     meldInput: MeldInput
   ) {
     let gameStageUpdated = false;
+    let currentActionUpdated = false;
     if (meldInput.meldType === 'fromHand') {
       const data = await this.playerActionsService.meldCardFromHand({
         cardId: meldInput.cardRef,
@@ -60,6 +61,11 @@ export class GameplayResolver {
           gameId: meldInput.gameRef,
         });
         gameStageUpdated = movedToActive;
+      } else if (meldInput.countAsAction) {
+        const updatedToNextAction = await this.playerActionsService.moveToNextGameAction({
+          gameId: meldInput.gameRef,
+        });
+        currentActionUpdated = updatedToNextAction;
       }
       return {
         gameId: meldInput.gameRef,
@@ -68,6 +74,7 @@ export class GameplayResolver {
         metadata: {
           updatedPlayerHand: data.updatedPlayerHand,
           gameStageUpdated,
+          currentActionUpdated,
         },
       };
     }

--- a/apps/backend/src/graphql/generated/schema.gql
+++ b/apps/backend/src/graphql/generated/schema.gql
@@ -215,6 +215,7 @@ input GetUserInput {
 
 input MeldInput {
   cardRef: ID!
+  countAsAction: Boolean!
   gameRef: ID!
   isStarterMeld: Boolean!
   meldType: String!
@@ -229,6 +230,8 @@ type MeldResponse {
 }
 
 type MeldResponseMetadata {
+  currentActionUpdated: Boolean!
+  gameStageUpdated: Boolean!
   updatedDeck: Deck!
   updatedPlayerHand: [ID!]!
 }

--- a/apps/backend/src/socket/dto/starter-card-melded.input.dto.ts
+++ b/apps/backend/src/socket/dto/starter-card-melded.input.dto.ts
@@ -1,8 +1,0 @@
-import { Board } from 'src/player-game-details/schemas/board.schema';
-import { PlayerGameDetails } from 'src/player-game-details/schemas/player-game-details.schema';
-
-export interface IStarterCardMeldedUpdatedData {
-  updatedPlayerId: string;
-  updatedPlayerBoard?: Board;
-  updatedPlayerHand?: Pick<PlayerGameDetails, 'hand'>;
-}

--- a/apps/backend/src/socket/services/socket-game.service.ts
+++ b/apps/backend/src/socket/services/socket-game.service.ts
@@ -12,19 +12,14 @@ import { getCatchErrorMessage } from '@inno/utils';
 
 import { GamesService } from 'src/games/games.service';
 
-import { IStarterCardMeldedUpdatedData } from '../dto/starter-card-melded.input.dto';
 import { ISocketServiceMethodParamsWithRoomId } from '../socket.types';
 
 export interface IParamsWithGameId extends ISocketServiceMethodParamsWithRoomId {
   gameId: string;
 }
 
-export interface IHandleMeldCardFromHandParams extends IParamsWithGameId {
-  cardId: string;
-}
-
-export interface IHandleStarterCardMelded extends ISocketServiceMethodParamsWithRoomId {
-  updatedData: IStarterCardMeldedUpdatedData;
+export interface IHandlePlayerMeldedCardParams extends ISocketServiceMethodParamsWithRoomId {
+  cardName: string;
 }
 
 @Injectable()
@@ -87,12 +82,10 @@ export class SocketGameService {
   /**
    * @name handleStarterCardMelded
    * @description handles emitting event to room notifying a player has melded their starter card
-   *              -> includes updated hand and board data for player who melded
    */
   async handleStarterCardMelded(
     socket: Socket,
     { roomId, user }: ISocketServiceMethodParamsWithRoomId
-    // { roomId, user, updatedData }: IHandleStarterCardMelded
   ) {
     try {
       if (!socket.rooms.has(roomId)) {
@@ -118,7 +111,56 @@ export class SocketGameService {
           userId: user._id,
           username: user.username,
         },
-        // updatedData,
+      });
+      return new SocketEventResponse({ success: true });
+    } catch (error) {
+      const errorMessage = getCatchErrorMessage(
+        error,
+        `Could not handle starter card meld: Unknown reason`
+      );
+      this.logger.error(errorMessage);
+      // TODO: handle error properly
+      // const errorData = new SocketEventError(SocketEventErrorCode.UNKNOWN, errorMessage);
+      // socket.emit(SocketEvent.START_GAME_ERROR, {
+      //   error: errorData,
+      // });
+      throw new WsException(errorMessage);
+    }
+  }
+
+  /**
+   * @name handlePlayerMeldedCard
+   * @description handles emitting event to room notifying a player has melded a card
+   */
+  async handlePlayerMeldedCard(
+    socket: Socket,
+    { cardName, roomId, user }: IHandlePlayerMeldedCardParams
+  ) {
+    try {
+      if (!socket.rooms.has(roomId)) {
+        this.logger.error(
+          `${user._id} could not notify card meld: User is not member of room ${roomId}`
+        );
+        const errorData = new SocketEventError(
+          SocketEventErrorCode.INVALID,
+          'User cannot emit events to room they are not a member of',
+          {
+            roomId,
+            userId: user._id,
+          }
+        );
+        return new SocketEventResponse({
+          success: false,
+          error: errorData,
+        });
+      }
+
+      socket.to(roomId).emit(SocketEvent.ROOM_CARD_MELDED, {
+        cardName,
+        meldedBy: {
+          userId: user._id,
+          username: user.username,
+        },
       });
       return new SocketEventResponse({ success: true });
     } catch (error) {

--- a/apps/backend/src/socket/socket.gateway.ts
+++ b/apps/backend/src/socket/socket.gateway.ts
@@ -134,4 +134,20 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       user,
     });
   }
+
+  @UseGuards(JwtWsAuthGuard)
+  @SubscribeMessage(SocketEvent.PLAYER_MELDED_CARD)
+  playerMeldedCard(
+    @CurrentUserFromRequest() user: UserWithoutPassword,
+    @MessageBody('roomId') roomId: string,
+    @MessageBody('cardName') cardName: string,
+    @ConnectedSocket() socket: Socket
+  ) {
+    return this.socketGameService.handlePlayerMeldedCard(socket, {
+      cardName,
+      roomId,
+      socketServer: this.server,
+      user,
+    });
+  }
 }

--- a/apps/native/src/app-core/constants/button.constants.ts
+++ b/apps/native/src/app-core/constants/button.constants.ts
@@ -1,0 +1,11 @@
+export const disabledSolidButtonClassnames = {
+  button: 'bg-gray-500',
+  buttonText: 'text-gray-100',
+  buttonIcon: 'text-gray-100',
+};
+
+export const disabledOutlineButtonClassnames = {
+  button: 'border-gray-500',
+  buttonText: 'text-gray-500',
+  buttonIcon: 'text-gray-500',
+};

--- a/apps/native/src/app-core/intl/en.ts
+++ b/apps/native/src/app-core/intl/en.ts
@@ -14,6 +14,8 @@ export const text = {
   },
   availableActions: {
     ACHIEVE_CTA: 'Achieve',
+    ACTION_NUMBER: 'Action Number',
+    CHOOSE_AN_ACTION: 'Select an action',
     CHOOSE_CARD_TO_ACHIEVE: 'Select a card to achieve',
     CHOOSE_CARD_TO_DOGMA: 'Select a card to dogma',
     CHOOSE_CARD_TO_MELD: 'Select a card to meld',

--- a/apps/native/src/games/components/active/actions/AvailableActions.tsx
+++ b/apps/native/src/games/components/active/actions/AvailableActions.tsx
@@ -1,20 +1,16 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { Box } from '../../../../app-core/components/gluestack/box';
 import { Button, ButtonText } from '../../../../app-core/components/gluestack/button';
+import { Heading } from '../../../../app-core/components/gluestack/heading';
 import { HStack } from '../../../../app-core/components/gluestack/hstack';
+import { disabledSolidButtonClassnames } from '../../../../app-core/constants/button.constants';
 import { text } from '../../../../app-core/intl/en';
 import { useCardsContext } from '../../../../cards/state/CardsProvider';
 import { useUserPlayerGameData } from '../../../hooks/useUserPlayerGameData';
 import { useGameContext } from '../../../state/GameProvider';
 
 import { GameActionSheet } from './GameActionSheet';
-
-export enum TurnAction {
-  ACHIEVE = 'ACHIEVE',
-  DOGMA = 'DOGMA',
-  DRAW = 'DRAW',
-  MELD = 'MELD',
-}
 
 export const AvailableActions = () => {
   const { cards } = useCardsContext();
@@ -65,10 +61,7 @@ export const AvailableActions = () => {
     // TODO: add achieve logic
   }, []);
 
-  if (
-    (gameMetadata?.currentPlayerId && gameMetadata.currentPlayerId !== playerId) ||
-    !possibleActions
-  ) {
+  if (!gameMetadata || gameMetadata.currentPlayerId !== playerId || !possibleActions) {
     return null;
   }
 
@@ -84,37 +77,58 @@ export const AvailableActions = () => {
     return playerMetadata.possibleActions.achieve.map((cid) => cards[cid]);
   }, [cards, playerMetadata?.possibleActions?.achieve]);
 
+  const isDrawDisabled = !possibleActions.draw;
+  const isMeldDisabled = !possibleActions.meld.length;
+  const isDogmaDisabled = !possibleActions.dogma.length;
+  const isAchieveDisabled = !possibleActions.achieve.length;
+
   return (
     <>
-      <HStack space="sm">
-        <Button
-          action={possibleActions.draw ? 'primary' : 'secondary'}
-          disabled={!possibleActions.draw}
-          onPress={handleDraw}
-        >
-          <ButtonText>{text.availableActions.DRAW_CTA}</ButtonText>
-        </Button>
-        <Button
-          action={possibleActions.meld.length ? 'primary' : 'secondary'}
-          disabled={!possibleActions.meld.length}
-          onPress={() => setShowMeldOptions(true)}
-        >
-          <ButtonText>{text.availableActions.MELD_CTA}</ButtonText>
-        </Button>
-        <Button
-          action={possibleActions.dogma.length ? 'primary' : 'secondary'}
-          disabled={!possibleActions.dogma.length}
-          onPress={() => setShowDogmaOptions(true)}
-        >
-          <ButtonText>{text.availableActions.DOGMA_CTA}</ButtonText>
-        </Button>
-        <Button
-          action={possibleActions.achieve.length ? 'primary' : 'secondary'}
-          disabled={!possibleActions.achieve.length}
-          onPress={() => setShowAchieveOptions(true)}
-        >
-          <ButtonText>{text.availableActions.ACHIEVE_CTA}</ButtonText>
-        </Button>
+      <HStack className="items-center justify-between">
+        <Heading size="md">{`${text.availableActions.ACTION_NUMBER}: ${gameMetadata?.currentActionNumber}`}</Heading>
+        <HStack space="sm" className="items-center">
+          <Box>
+            <Heading size="md">{text.availableActions.CHOOSE_AN_ACTION}</Heading>
+          </Box>
+          <Button
+            className={isDrawDisabled ? disabledSolidButtonClassnames.button : ''}
+            disabled={isDrawDisabled}
+            onPress={handleDraw}
+          >
+            <ButtonText className={isDrawDisabled ? disabledSolidButtonClassnames.buttonText : ''}>
+              {text.availableActions.DRAW_CTA}
+            </ButtonText>
+          </Button>
+          <Button
+            className={isMeldDisabled ? disabledSolidButtonClassnames.button : ''}
+            disabled={isMeldDisabled}
+            onPress={() => setShowMeldOptions(true)}
+          >
+            <ButtonText className={isMeldDisabled ? disabledSolidButtonClassnames.buttonText : ''}>
+              {text.availableActions.MELD_CTA}
+            </ButtonText>
+          </Button>
+          <Button
+            className={isDogmaDisabled ? disabledSolidButtonClassnames.button : ''}
+            disabled={isDogmaDisabled}
+            onPress={() => setShowDogmaOptions(true)}
+          >
+            <ButtonText className={isDogmaDisabled ? disabledSolidButtonClassnames.buttonText : ''}>
+              {text.availableActions.DOGMA_CTA}
+            </ButtonText>
+          </Button>
+          <Button
+            className={isAchieveDisabled ? disabledSolidButtonClassnames.button : ''}
+            disabled={isAchieveDisabled}
+            onPress={() => setShowAchieveOptions(true)}
+          >
+            <ButtonText
+              className={isAchieveDisabled ? disabledSolidButtonClassnames.buttonText : ''}
+            >
+              {text.availableActions.ACHIEVE_CTA}
+            </ButtonText>
+          </Button>
+        </HStack>
       </HStack>
       <GameActionSheet
         cards={possibleCardsToMeld}

--- a/apps/native/src/games/components/active/actions/AvailableActions.tsx
+++ b/apps/native/src/games/components/active/actions/AvailableActions.tsx
@@ -11,20 +11,16 @@ import { useUserPlayerGameData } from '../../../hooks/useUserPlayerGameData';
 import { useGameContext } from '../../../state/GameProvider';
 
 import { GameActionSheet } from './GameActionSheet';
+import { MeldAction } from './MeldAction';
 
 export const AvailableActions = () => {
   const { cards } = useCardsContext();
   const { metadata: gameMetadata } = useGameContext();
   const { metadata: playerMetadata, playerId } = useUserPlayerGameData() ?? {};
-  const [showMeldOptions, setShowMeldOptions] = useState(false);
   const [showDogmaOptions, setShowDogmaOptions] = useState(false);
   const [showAchieveOptions, setShowAchieveOptions] = useState(false);
 
   const possibleActions = playerMetadata?.possibleActions;
-
-  const closeMeldOptions = useCallback(() => {
-    setShowMeldOptions(false);
-  }, []);
 
   const closeDogmaOptions = useCallback(() => {
     setShowDogmaOptions(false);
@@ -43,12 +39,6 @@ export const AvailableActions = () => {
     // TODO: add draw logic
   }, [playerMetadata?.possibleActions.draw]);
 
-  const handleMeldSelection = useCallback((cardId: string) => {
-    console.log('SELECTED CARD TO MELD: ', cardId);
-    setShowMeldOptions(false);
-    // TODO: add meld logic
-  }, []);
-
   const handleDogmaSelection = useCallback((cardId: string) => {
     console.log('SELECTED CARD TO DOGMA: ', cardId);
     setShowDogmaOptions(false);
@@ -65,10 +55,6 @@ export const AvailableActions = () => {
     return null;
   }
 
-  const possibleCardsToMeld = useMemo(() => {
-    return playerMetadata.possibleActions.meld.map((cid) => cards[cid]);
-  }, [cards, playerMetadata?.possibleActions?.meld]);
-
   const possibleCardsToDogma = useMemo(() => {
     return playerMetadata.possibleActions.dogma.map((cid) => cards[cid]);
   }, [cards, playerMetadata?.possibleActions?.dogma]);
@@ -78,7 +64,6 @@ export const AvailableActions = () => {
   }, [cards, playerMetadata?.possibleActions?.achieve]);
 
   const isDrawDisabled = !possibleActions.draw;
-  const isMeldDisabled = !possibleActions.meld.length;
   const isDogmaDisabled = !possibleActions.dogma.length;
   const isAchieveDisabled = !possibleActions.achieve.length;
 
@@ -99,15 +84,7 @@ export const AvailableActions = () => {
               {text.availableActions.DRAW_CTA}
             </ButtonText>
           </Button>
-          <Button
-            className={isMeldDisabled ? disabledSolidButtonClassnames.button : ''}
-            disabled={isMeldDisabled}
-            onPress={() => setShowMeldOptions(true)}
-          >
-            <ButtonText className={isMeldDisabled ? disabledSolidButtonClassnames.buttonText : ''}>
-              {text.availableActions.MELD_CTA}
-            </ButtonText>
-          </Button>
+          <MeldAction />
           <Button
             className={isDogmaDisabled ? disabledSolidButtonClassnames.button : ''}
             disabled={isDogmaDisabled}
@@ -130,13 +107,6 @@ export const AvailableActions = () => {
           </Button>
         </HStack>
       </HStack>
-      <GameActionSheet
-        cards={possibleCardsToMeld}
-        headerText={text.availableActions.CHOOSE_CARD_TO_MELD}
-        onClose={closeMeldOptions}
-        onSelect={handleMeldSelection}
-        visible={showMeldOptions}
-      />
       <GameActionSheet
         cards={possibleCardsToDogma}
         headerText={text.availableActions.CHOOSE_CARD_TO_DOGMA}

--- a/apps/native/src/games/components/active/actions/MeldAction.tsx
+++ b/apps/native/src/games/components/active/actions/MeldAction.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { SocketEvent } from '@inno/constants';
+
+import { Button, ButtonText } from '../../../../app-core/components/gluestack/button';
+import { useToast } from '../../../../app-core/components/gluestack/toast';
+import { CustomToast } from '../../../../app-core/components/toasts/CustomToast';
+import { disabledSolidButtonClassnames } from '../../../../app-core/constants/button.constants';
+import { text } from '../../../../app-core/intl/en';
+import { useAuthContext } from '../../../../authentication/state/AuthProvider';
+import { useCardsContext } from '../../../../cards/state/CardsProvider';
+import { useRoomContext } from '../../../../rooms/state/RoomProvider';
+import { useSocketContext } from '../../../../websockets/SocketProvider';
+import { useMeldCard } from '../../../hooks/useMeldCard';
+import { useUserPlayerGameData } from '../../../hooks/useUserPlayerGameData';
+import { useGameContext } from '../../../state/GameProvider';
+
+import { GameActionSheet } from './GameActionSheet';
+
+export interface IRoomCardMeldedCallbackProps {
+  cardName: string;
+  meldedBy: { username: string; userId: string };
+}
+
+export const MeldAction = () => {
+  const { user } = useAuthContext();
+  const { cards } = useCardsContext();
+  const { currentRoomId } = useRoomContext();
+  const { metadata: gameMetadata } = useGameContext();
+  const { metadata: playerMetadata, playerId } = useUserPlayerGameData() ?? {};
+  // TODO: handle any error melding
+  const { loading: meldingInProgress, meldCardFromHand } = useMeldCard();
+  const { socket } = useSocketContext();
+  const toast = useToast();
+  const [showMeldOptions, setShowMeldOptions] = useState(false);
+
+  const possibleActions = playerMetadata?.possibleActions;
+
+  useEffect(() => {
+    socket?.on(
+      SocketEvent.ROOM_STARTER_CARD_MELDED,
+      ({ cardName, meldedBy }: IRoomCardMeldedCallbackProps) => {
+        if (user?._id && user._id !== meldedBy.userId) {
+          toast.show({
+            placement: 'top',
+            render: ({ id }) => (
+              <CustomToast
+                id={id}
+                title="Card Melded"
+                description={`${meldedBy.username} melded ${cardName}`}
+              />
+            ),
+          });
+        }
+      }
+    );
+    return () => {
+      socket?.removeListener(SocketEvent.GAME_UPDATED);
+    };
+  }, [socket]);
+
+  const closeMeldOptions = useCallback(() => {
+    setShowMeldOptions(false);
+  }, []);
+
+  const emitCardMeldedEvent = (cardId: string) => {
+    if (!socket || !cards) {
+      return;
+    }
+    const cardName = cards[cardId].name;
+    socket.emit(SocketEvent.PLAYER_MELDED_CARD, { cardName, roomId: currentRoomId });
+  };
+
+  const handleMeldSelection = useCallback((cardId: string) => {
+    setShowMeldOptions(false);
+    meldCardFromHand({
+      cardId,
+      countAsAction: true,
+      onSuccess: () => emitCardMeldedEvent(cardId),
+    });
+  }, []);
+
+  if (!gameMetadata || gameMetadata.currentPlayerId !== playerId || !possibleActions) {
+    return null;
+  }
+
+  const possibleCardsToMeld = useMemo(() => {
+    return playerMetadata.possibleActions.meld.map((cid) => cards[cid]);
+  }, [cards, playerMetadata?.possibleActions?.meld]);
+
+  const isMeldDisabled = !possibleActions.meld.length || meldingInProgress;
+
+  return (
+    <>
+      <Button
+        className={isMeldDisabled ? disabledSolidButtonClassnames.button : ''}
+        disabled={isMeldDisabled}
+        onPress={() => setShowMeldOptions(true)}
+      >
+        <ButtonText className={isMeldDisabled ? disabledSolidButtonClassnames.buttonText : ''}>
+          {text.availableActions.MELD_CTA}
+        </ButtonText>
+      </Button>
+      <GameActionSheet
+        cards={possibleCardsToMeld}
+        headerText={text.availableActions.CHOOSE_CARD_TO_MELD}
+        onClose={closeMeldOptions}
+        onSelect={handleMeldSelection}
+        visible={showMeldOptions}
+      />
+    </>
+  );
+};

--- a/apps/native/src/games/components/setup/SelectStarterCard.tsx
+++ b/apps/native/src/games/components/setup/SelectStarterCard.tsx
@@ -38,6 +38,7 @@ export const SelectStarterCard: FC = () => {
     }
     meldCardFromHand({
       cardId: selectedCardRef,
+      countAsAction: false,
       isStarterMeld: true,
       onSuccess: emitSocketStarterCardMeldedEvent,
     });

--- a/apps/native/src/games/hooks/useMeldCard.ts
+++ b/apps/native/src/games/hooks/useMeldCard.ts
@@ -16,10 +16,12 @@ export const useMeldCard = () => {
 
   const meldCardFromHand = ({
     cardId,
+    countAsAction = true,
     isStarterMeld = false,
     onSuccess,
   }: {
     cardId: string;
+    countAsAction?: boolean;
     isStarterMeld?: boolean;
     onSuccess?: () => void;
   }) => {
@@ -31,6 +33,7 @@ export const useMeldCard = () => {
       variables: {
         meldInput: {
           cardRef: cardId,
+          countAsAction,
           gameRef: gameId,
           isStarterMeld,
           playerRef: user._id,

--- a/packages/constants/src/sockets.ts
+++ b/packages/constants/src/sockets.ts
@@ -35,15 +35,16 @@ export enum SocketEvent {
   GET_ROOM_METADATA = 'getRoomMetadata',
   JOIN_ROOM = 'joinRoom',
   MAP_USER_TO_SOCKET = 'mapUserToSocket',
+  PLAYER_MELDED_CARD = 'playerMeldedCard',
   START_GAME = 'startGame',
   STARTER_CARD_MELDED = 'starterCardMelded',
 
   // event emitted to rooms
-  CARD_MELDED = 'cardMelded',
   CLOSE_ROOM_IN_PROGRESS = 'closeRoomInProgress',
   CLOSE_ROOM_SUCCESS = 'closeRoomSuccess',
   GAME_STARTED = 'gameStarted',
   GAME_UPDATED = 'gameUpdated',
+  ROOM_CARD_MELDED = 'roomCardMelded',
   ROOM_STARTER_CARD_MELDED = 'roomStarterCardMelded',
   USER_JOINED_ROOM = 'userJoinedRoom',
   USER_LEFT_ROOM = 'userLeftRoom',

--- a/packages/gql/generated/graphql.tsx
+++ b/packages/gql/generated/graphql.tsx
@@ -241,6 +241,7 @@ export type GetUserInput = {
 
 export type MeldInput = {
   cardRef: Scalars['ID']['input'];
+  countAsAction: Scalars['Boolean']['input'];
   gameRef: Scalars['ID']['input'];
   isStarterMeld: Scalars['Boolean']['input'];
   meldType: Scalars['String']['input'];
@@ -257,6 +258,8 @@ export type MeldResponse = {
 
 export type MeldResponseMetadata = {
   __typename?: 'MeldResponseMetadata';
+  currentActionUpdated: Scalars['Boolean']['output'];
+  gameStageUpdated: Scalars['Boolean']['output'];
   updatedDeck: Deck;
   updatedPlayerHand: Array<Scalars['ID']['output']>;
 };


### PR DESCRIPTION
## Summary

### Backend
- Updated GQL `meld` resolver to handle regular meld logic
- Added `moveToNextGameAction` method to `PlayerActionsService` to handle updating action number and [maybe] player id if next action goes to a new player

### Native
- Moved meld game action to separate component (`MeldAction`)
- Added actual meld logic
- Fixed disabled button sling

## Demo


https://github.com/user-attachments/assets/5c463707-7558-4f34-8431-315c3ba1eaff

